### PR TITLE
Feature/qd build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cmake-build-debug/
 CMakeFiles
 Makefile
 venv
+.vscode/

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -1,0 +1,29 @@
+Change log
+==========
+
+Changes made by Quantum Detectors to this repository are recorded below.
+
+0.5.0qd0-1
+----------
+
+Added:
+
+- WIP of X3X2 list mode decoder plugin
+
+Changed:
+
+- C++ control server
+  - now configures X3X2 clocks
+  - now enables resets in list mode
+  - Xspress library configure call explicitly requests list readout mode
+- Python control server
+  - requests X3X2 list mode decoder plugin on configure to list mode
+  - changed number of channels used in list mode
+  - changed frame receiver IP/port configuration (currently listens to
+    scalars socket to leave event TCP/IP socket free for Python)
+
+Fixed:
+
+- Now use Xspress library method `xsp3_histogram_read4d` when reading X3X2 MCA
+  data
+- Set num_cards when detector is configured in control server

--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -183,6 +183,7 @@ public:
   virtual int set_window(int chan, int sca, int llm, int hlm) = 0;
   virtual int set_sca_thresh(int chan, int value) = 0;
   virtual int set_trigger_input(bool list_mode) = 0;
+  virtual int setup_clocks(int num_cards) = 0;
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -184,6 +184,7 @@ public:
   virtual int set_sca_thresh(int chan, int value) = 0;
   virtual int set_trigger_input(bool list_mode) = 0;
   virtual int setup_clocks(int num_cards) = 0;
+  virtual int enable_list_mode_resets() = 0;
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -154,6 +154,7 @@ public:
   int set_window(int chan, int sca, int llm, int hlm);
   int set_sca_thresh(int chan, int value);
   int set_trigger_input(bool list_mode);
+  int setup_clocks(int num_cards);
 
 private:
   /** String representation of trigger modes */

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -155,6 +155,7 @@ public:
   int set_sca_thresh(int chan, int value);
   int set_trigger_input(bool list_mode);
   int setup_clocks(int num_cards);
+  int enable_list_mode_resets();
 
 private:
   /** String representation of trigger modes */

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -191,6 +191,7 @@ public:
   int set_sca_thresh(int chan, int value);
   int set_trigger_input(bool list_mode);
   int setup_clocks(int num_cards);
+  int enable_list_mode_resets();
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -190,6 +190,7 @@ public:
   int set_window(int chan, int sca, int llm, int hlm);
   int set_sca_thresh(int chan, int value);
   int set_trigger_input(bool list_mode);
+  int setup_clocks(int num_cards);
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/XspressDetector.h
+++ b/cpp/control/include/XspressDetector.h
@@ -61,6 +61,7 @@ public:
   bool checkConnected();
   int disconnect();
   int setupChannels();
+  int setupClocks();
   int enableDAQ();
   int checkSaveDir(const std::string& dir_name);
   int saveSettings();

--- a/cpp/control/include/XspressDetector.h
+++ b/cpp/control/include/XspressDetector.h
@@ -62,6 +62,7 @@ public:
   int disconnect();
   int setupChannels();
   int setupClocks();
+  int setupControlRegister();
   int enableDAQ();
   int checkSaveDir(const std::string& dir_name);
   int saveSettings();

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -957,4 +957,10 @@ int LibXspressSimulator::set_trigger_input(bool list_mode)
   return XSP_STATUS_OK;
 }
 
+int LibXspressSimulator::setup_clocks(int num_cards)
+{
+  // This is a no op for the simulator
+  return XSP_STATUS_OK;
+}
+
 } /* namespace Xspress */

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -963,4 +963,10 @@ int LibXspressSimulator::setup_clocks(int num_cards)
   return XSP_STATUS_OK;
 }
 
+int LibXspressSimulator::enable_list_mode_resets()
+{
+  // This is a no op for the simulator
+  return XSP_STATUS_OK;
+}
+
 } /* namespace Xspress */

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -864,7 +864,11 @@ int LibXspressWrapper::get_num_frames_read(int32_t *frames)
     if (flags != 0){
       // TODO: check what to do about this permanently - ignore playback under-run which happens on Mk2 a lot?
       // If so, should identify whether mark 2 and then check ignore
-      // if (flags == Xsp3ErrFlag::Xsp3ErrFlag_Playback) return status;
+      if (flags == Xsp3ErrFlag::Xsp3ErrFlag_Playback)
+      {
+        LOG4CXX_DEBUG_LEVEL(2, logger_, "Got playback under-run (ignoring)");
+        return status;
+      }
 
       std::stringstream ss;
       ss << "xsp3_scaler_check_progress_details reported error flags [" << flags << "]";

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -864,11 +864,7 @@ int LibXspressWrapper::get_num_frames_read(int32_t *frames)
     if (flags != 0){
       // TODO: check what to do about this permanently - ignore playback under-run which happens on Mk2 a lot?
       // If so, should identify whether mark 2 and then check ignore
-      if (flags == Xsp3ErrFlag::Xsp3ErrFlag_Playback)
-      {
-        LOG4CXX_DEBUG_LEVEL(2, logger_, "Got playback under-run (ignoring)");
-        return status;
-      }
+      if (flags == Xsp3ErrFlag::Xsp3ErrFlag_Playback) return status;
 
       std::stringstream ss;
       ss << "xsp3_scaler_check_progress_details reported error flags [" << flags << "]";

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1008,11 +1008,6 @@ int LibXspressWrapper::histogram_memcpy(uint32_t *buffer,
 {
   int status = XSP_STATUS_OK;
   int xsp_status;
-  uint32_t twrap;
-  uint32_t *frame_ptr;
-  int rc;
-  int thisPath, chanIdx;
-  bool circ_buffer;
 
   if (xsp_handle_ < 0 || xsp_handle_ >= XSP3_MAX_PATH || !Xsp3Sys[xsp_handle_].valid){
     checkErrorCode("histogram_memcpy", XSP3_INVALID_PATH);
@@ -1031,14 +1026,19 @@ int LibXspressWrapper::histogram_memcpy(uint32_t *buffer,
         << num_eng << ", " << num_aux << ", " << num_chan << ", " << num_tf
       );
       // int xsp3_histogram_read4d(int path, u_int32_t *buffer, unsigned eng, unsigned aux, unsigned chan, unsigned tf, unsigned num_eng, unsigned num_aux, unsigned num_chan, unsigned num_tf)
-      xsp_status = xsp3m_histogram_read_frames(xsp_handle_, buffer, 0, 0, start_chan, tf, num_eng, num_aux, num_chan, num_tf);
+      //xsp_status = xsp3_histogram_read4d(xsp_handle_, buffer, 0, 0, start_chan, tf, num_eng, num_aux, num_chan, num_tf);
+      xsp_status = xsp3m_histogram_read_frames(xsp_handle_, buffer, 0, start_chan, tf, num_eng, num_chan, num_tf);
       if (xsp_status < XSP3_OK){
         checkErrorCode("xsp3_histogram_read_frames", xsp_status);
         status = XSP_STATUS_ERROR;
       }
     }
     else {
-      circ_buffer = (bool)(Xsp3Sys[xsp_handle_].run_flags & XSP3_RUN_FLAGS_CIRCULAR_BUFFER);
+      uint32_t twrap;
+      uint32_t *frame_ptr;
+      int thisPath, chanIdx;
+
+      bool circ_buffer = (bool)(Xsp3Sys[xsp_handle_].run_flags & XSP3_RUN_FLAGS_CIRCULAR_BUFFER);
       if (tf > total_tf && !circ_buffer) {
         LOG4CXX_ERROR(logger_, "Requested timeframe " << tf << " lies beyond end of buffer (length " << total_tf <<")");
         checkErrorCode("xsp3_histogram_memcpy", XSP3_RANGE_CHECK);

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -337,6 +337,7 @@ int LibXspressWrapper::get_clock_period(double& clock_period)
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper calling xsp3_get_clock_period");
   // Read the clock period
   clock_period = xsp3_get_clock_period(xsp_handle_, 0);
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Got clock period: " << clock_period << "Hz");
   return status;
 }
 

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -166,26 +166,6 @@ int LibXspressWrapper::configure_mca(int num_cards,                 // Number of
     checkErrorCode("xsp3_config", xsp_handle_);
   }
 
-  // Check the clock signal for X3X2 systems
-  if (status == 0 && xsp3_is_xsp3m_plus(0) == 1)
-  {
-    LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 midplane clock");
-    for (unsigned int card = 0; card < num_cards; card++)
-    {
-      status = xsp3_clocks_setup(
-        xsp_handle_,
-        card,
-        XSP4_CLK_SRC_MIDPLN_LMK61E2,
-        XSP3_CLK_FLAGS_MASTER | XSP3_CLK_FLAGS_NO_DITHER,
-        0
-      );
-      if (status < 0) checkErrorCode("Error configuring X3X2 clocks", status);
-    }
-    LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 sync mode");
-    status = xsp3_set_sync_mode(xsp_handle_, XSP3_SYNC_MODE(XSP3_SYNC_MIDPLANE), 0, 0);
-    checkErrorCode("Error configuring X3X2 sync mode", status);
-  }
-
   return status;
 }
 
@@ -843,6 +823,26 @@ int LibXspressWrapper::setTriggerMode(int frames,
   Xsp3Timing xsp_trigger_mode = {0};
   int itfg_trig_mode;
   int xsp_status = XSP3_OK;
+
+  // Check the clock signal for X3X2 systems
+  if (status == 0 && xsp3_is_xsp3m_plus(0) == 1)
+  {
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 midplane clock");
+    for (unsigned int card = 0; card < num_cards; card++)
+    {
+      status = xsp3_clocks_setup(
+        xsp_handle_,
+        card,
+        XSP4_CLK_SRC_MIDPLN_LMK61E2,
+        XSP3_CLK_FLAGS_MASTER | XSP3_CLK_FLAGS_NO_DITHER,
+        0
+      );
+      if (status < 0) checkErrorCode("Error configuring X3X2 clocks", status);
+    }
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 sync mode");
+    status = xsp3_set_sync_mode(xsp_handle_, XSP3_SYNC_MODE(XSP3_SYNC_MIDPLANE), 0, 0);
+    checkErrorCode("Error configuring X3X2 sync mode", status);
+  }
 
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper calling xsp3_itfg_setup and xsp3_set_timing");  
 

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1247,7 +1247,16 @@ int LibXspressWrapper::enable_list_mode_resets()
   {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper enabling list mode resets for X3X2");
 
+    // The second general control register is used - apply to all channels
+    xsp_status = xsp3_set_chan_cont2(xsp_handle_, -1, XSP3M_CC2_SEND_RESET_WIDTHS);
+    if (xsp_status < 0)
+    {
+      checkErrorCode("xsp3_set_chan_cont2", xsp_status);
+      status = XSP_STATUS_ERROR;
+    }
+
     // Need to enable each channel individually to preserve the current control register value
+    /*
     int num_chan = xsp3_get_num_chan(xsp_handle_);
     if (num_chan < 0)
     {
@@ -1270,8 +1279,8 @@ int LibXspressWrapper::enable_list_mode_resets()
         else
         {
           LOG4CXX_INFO(logger_, "Channel " << chan << " current control register value: " << current_register_value);
-          // Add the reset list to the register
-          xsp_status = xsp3_set_chan_cont(xsp_handle_, chan, current_register_value | XSP3M_CC2_SEND_RESET_WIDTHS);
+          // Add the reset list to the register (lives on CC2)
+          xsp_status = xsp3_set_chan_cont2(xsp_handle_, chan, current_register_value | XSP3M_CC2_SEND_RESET_WIDTHS);
           if (xsp_status < 0)
           {
             checkErrorCode("xsp3_set_chan_cont", xsp_status);
@@ -1280,7 +1289,7 @@ int LibXspressWrapper::enable_list_mode_resets()
         }
       }
     }
-
+    */
   }
 
   return status;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1025,6 +1025,8 @@ int LibXspressWrapper::histogram_memcpy(uint32_t *buffer,
     circ_buffer = (bool)(Xsp3Sys[xsp_handle_].run_flags & XSP3_RUN_FLAGS_CIRCULAR_BUFFER);
 
     if (Xsp3Sys[xsp_handle_].features.generation == XspressGen3Mini){
+      // TODO: remove this when finished debugging
+      LOG4CXX_DEBUG_LEVEL(1, logger_, "calling xsp3_histogram_read4d with start channel " << start_chan << " and num_chan " << num_chan);
       xsp_status = xsp3_histogram_read4d(xsp_handle_, buffer, 0, 0, start_chan, tf, num_eng, num_aux, num_chan, num_tf);
       if (xsp_status < XSP3_OK){
         checkErrorCode("xsp3_histogram_read_frames", xsp_status);

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1248,15 +1248,16 @@ int LibXspressWrapper::enable_list_mode_resets()
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper enabling list mode resets for X3X2");
 
     // The second general control register is used - apply to all channels
+    /*
     int xsp_status = xsp3_set_chan_cont2(xsp_handle_, -1, XSP3M_CC2_SEND_RESET_WIDTHS);
     if (xsp_status < 0)
     {
       checkErrorCode("xsp3_set_chan_cont2", xsp_status);
       status = XSP_STATUS_ERROR;
     }
+    */
 
     // Need to enable each channel individually to preserve the current control register value
-    /*
     int num_chan = xsp3_get_num_chan(xsp_handle_);
     if (num_chan < 0)
     {
@@ -1270,7 +1271,8 @@ int LibXspressWrapper::enable_list_mode_resets()
       u_int32_t current_register_value = 0;
       for (int chan = 0; chan < num_chan; chan++)
       {
-        int xsp_status = xsp3_get_chan_cont(xsp_handle_, chan, &current_register_value);
+        //int xsp_status = xsp3_get_chan_cont(xsp_handle_, chan, &current_register_value);
+        int xsp_status = xsp3_read_reg(path, chan, XSP3_REGION_REGS, XSP3_CHAN_CONT2, 1, &current_register_value);
         if (xsp_status < 0)
         {
           checkErrorCode("xsp3_get_chan_cont", xsp_status);
@@ -1286,10 +1288,14 @@ int LibXspressWrapper::enable_list_mode_resets()
             checkErrorCode("xsp3_set_chan_cont", xsp_status);
             status = XSP_STATUS_ERROR;
           }
+
+          // Try getting value again
+          xsp_status = xsp3_read_reg(path, chan, XSP3_REGION_REGS, XSP3_CHAN_CONT2, 1, &current_register_value);
+          LOG4CXX_INFO(logger_, "Channel " << chan << " new control register value: " << current_register_value);
+
         }
       }
     }
-    */
   }
 
   return status;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1017,7 +1017,7 @@ int LibXspressWrapper::histogram_memcpy(uint32_t *buffer,
     circ_buffer = (bool)(Xsp3Sys[xsp_handle_].run_flags & XSP3_RUN_FLAGS_CIRCULAR_BUFFER);
 
     if (Xsp3Sys[xsp_handle_].features.generation == XspressGen3Mini){
-      xsp_status = xsp3_histogram_read4d(xsp_handle_, buffer, 0, 0, start_chan, tf, num_eng, num_chan, num_tf)
+      xsp_status = xsp3_histogram_read4d(xsp_handle_, buffer, 0, 0, start_chan, tf, num_eng, num_aux, num_chan, num_tf)
       // xsp_status = xsp3m_histogram_read_frames(xsp_handle_, buffer, 0, start_chan, tf, num_eng, num_chan, num_tf);
       if (xsp_status < XSP3_OK){
         checkErrorCode("xsp3_histogram_read_frames", xsp_status);

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1284,7 +1284,7 @@ int LibXspressWrapper::enable_list_mode_resets()
         {
           LOG4CXX_INFO(logger_, "Channel " << chan << " current cont: " << current_cont_value << ", cont2: " << current_cont2_value);
           // Enable reset ticks
-          xsp_status = xsp3_set_chan_cont(xsp_handle_, chan, current_cont_value | XSP3_CC_LIVE_TICKS_MODE(XSP3_CC_LT_RESET_TICKS));
+          xsp_status = xsp3_set_chan_cont(xsp_handle_, chan, current_cont_value | XSP3_CC_SEND_RESET_WIDTHS);
           // Add the reset list to the register (lives on CC2)
           xsp_status |= xsp3_set_chan_cont2(xsp_handle_, chan, current_cont2_value | XSP3M_CC2_SEND_RESET_WIDTHS);
           if (xsp_status < 0)

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -337,7 +337,6 @@ int LibXspressWrapper::get_clock_period(double& clock_period)
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper calling xsp3_get_clock_period");
   // Read the clock period
   clock_period = xsp3_get_clock_period(xsp_handle_, 0);
-  LOG4CXX_DEBUG_LEVEL(1, logger_, "Got clock period: " << clock_period << "Hz");
   return status;
 }
 

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -180,7 +180,8 @@ int LibXspressWrapper::configure_list(int num_cards,                 // Number o
   int status = XSP_STATUS_OK;
   LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper calling xsp3_config_init");
 
-  // Setup initialisation flags to allow alternate UDP RX sockets using the default ports
+  // Setup initialisation flags to prevent Xspress library from connecting it's own
+  // sockets to the Xspress cards to allow us to read from the sockets instead
   int do_init = Xsp3Init_Normal | Xsp3InitUDP_DisHistThreads;
 
   // Call the more detailed config init function

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -179,10 +179,10 @@ int LibXspressWrapper::configure_mca(int num_cards,                 // Number of
         XSP3_CLK_FLAGS_MASTER | XSP3_CLK_FLAGS_NO_DITHER,
         0
       );
-      checkErrorCode(status, "Error configuring X3X2 clocks");
+      checkErrorCode("Error configuring X3X2 clocks", status);
     }
     status = xsp3_set_sync_mode(xsp_handle_, XSP3_SYNC_MODE(XSP3_SYNC_MIDPLANE), 0, 0);
-    checkErrorCode(status, "Error configuring X3X2 sync mode");
+    checkErrorCode("Error configuring X3X2 sync mode", status);
   }
 
   return status;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -862,6 +862,13 @@ int LibXspressWrapper::get_num_frames_read(int32_t *frames)
     status = XSP_STATUS_ERROR;
   } else {
     if (flags != 0){
+      // TODO: check what to do about this permanently - ignore playback under-run which happens on Mk2 a lot?
+      if (flags == Xsp3ErrFlag::Xsp3ErrFlag_Playback)
+      {
+        LOG4CXX_DEBUG_LEVEL(1, logger_, "Ignoring playback underrun");
+        return status;
+      }
+
       std::stringstream ss;
       ss << "xsp3_scaler_check_progress_details reported error flags [" << flags << "]";
       setErrorString(ss.str());

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1248,7 +1248,7 @@ int LibXspressWrapper::enable_list_mode_resets()
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper enabling list mode resets for X3X2");
 
     // The second general control register is used - apply to all channels
-    xsp_status = xsp3_set_chan_cont2(xsp_handle_, -1, XSP3M_CC2_SEND_RESET_WIDTHS);
+    int xsp_status = xsp3_set_chan_cont2(xsp_handle_, -1, XSP3M_CC2_SEND_RESET_WIDTHS);
     if (xsp_status < 0)
     {
       checkErrorCode("xsp3_set_chan_cont2", xsp_status);

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1272,7 +1272,7 @@ int LibXspressWrapper::enable_list_mode_resets()
       for (int chan = 0; chan < num_chan; chan++)
       {
         //int xsp_status = xsp3_get_chan_cont(xsp_handle_, chan, &current_register_value);
-        int xsp_status = xsp3_read_reg(path, chan, XSP3_REGION_REGS, XSP3_CHAN_CONT2, 1, &current_register_value);
+        int xsp_status = xsp3_read_reg(xsp_handle_, chan, XSP3_REGION_REGS, XSP3_CHAN_CONT2, 1, &current_register_value);
         if (xsp_status < 0)
         {
           checkErrorCode("xsp3_get_chan_cont", xsp_status);
@@ -1290,7 +1290,7 @@ int LibXspressWrapper::enable_list_mode_resets()
           }
 
           // Try getting value again
-          xsp_status = xsp3_read_reg(path, chan, XSP3_REGION_REGS, XSP3_CHAN_CONT2, 1, &current_register_value);
+          xsp_status = xsp3_read_reg(xsp_handle_, chan, XSP3_REGION_REGS, XSP3_CHAN_CONT2, 1, &current_register_value);
           LOG4CXX_INFO(logger_, "Channel " << chan << " new control register value: " << current_register_value);
 
         }

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1027,13 +1027,24 @@ int LibXspressWrapper::histogram_memcpy(uint32_t *buffer,
 
     if (Xsp3Sys[xsp_handle_].features.generation == XspressGen3Mini){
       // TODO: remove this when finished debugging
-      LOG4CXX_DEBUG_LEVEL(1, logger_, "calling xsp3_histogram_read4d with start channel " << start_chan << " and num_chan " << num_chan);
+      LOG4CXX_DEBUG_LEVEL(
+        1,
+        logger_,
+        "xsp3_histogram_read4d"
+        << " start_chan " << start_chan
+        << " num_chan " << num_chan
+        << " start tf" << tf
+        << " eng aux chan tf"
+        << num_eng << ", " << num_aux << ", " << num_chan << ", " << num_tf
+      );
+      // int xsp3_histogram_read4d(int path, u_int32_t *buffer, unsigned eng, unsigned aux, unsigned chan, unsigned tf, unsigned num_eng, unsigned num_aux, unsigned num_chan, unsigned num_tf)
       xsp_status = xsp3_histogram_read4d(xsp_handle_, buffer, 0, 0, start_chan, tf, num_eng, num_aux, num_chan, num_tf);
       if (xsp_status < XSP3_OK){
         checkErrorCode("xsp3_histogram_read_frames", xsp_status);
         status = XSP_STATUS_ERROR;
       }
-    } else {
+    }
+    else {
       if (tf > total_tf && !circ_buffer) {
         LOG4CXX_ERROR(logger_, "Requested timeframe " << tf << " lies beyond end of buffer (length " << total_tf <<")");
         checkErrorCode("xsp3_histogram_memcpy", XSP3_RANGE_CHECK);

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1013,9 +1013,7 @@ int LibXspressWrapper::histogram_memcpy(uint32_t *buffer,
     checkErrorCode("histogram_memcpy", XSP3_INVALID_PATH);
     status = XSP_STATUS_ERROR;
   } else {
-    // TODO: remove when testing finished
-    bool fallback = false;
-    if (Xsp3Sys[xsp_handle_].features.generation == XspressGen3Mini && fallback == true){
+    if (Xsp3Sys[xsp_handle_].features.generation == XspressGen3Mini){
       // TODO: remove this when finished debugging
       LOG4CXX_DEBUG_LEVEL(
         1,

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -196,7 +196,7 @@ int LibXspressWrapper::configure_list(int num_cards,                 // Number o
     debug,                                  // Enable debug messages
     0,                                      // Card index
     (Xsp3Init)do_init,                      // Initialisation flags
-    Xsp3mRd_Auto,                           // Xsp3mRd_Auto
+    Xsp3mRd_SendHistList,                   // Configure readout for list mode
     XspressReal                             // XspressReal
   );
 
@@ -1176,6 +1176,7 @@ int LibXspressWrapper::set_trigger_input(bool list_mode)
   memset(&trig_mux, 0, sizeof(Xsp3TriggerMux));
 
   if (list_mode){
+    // TODO: Ben: check if these are correct
     trig_mux.trig_sel[0] = 0;
     trig_mux.trig_sel[1] = 2;
     trig_mux.trig_sel[2] = 1;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1013,7 +1013,9 @@ int LibXspressWrapper::histogram_memcpy(uint32_t *buffer,
     checkErrorCode("histogram_memcpy", XSP3_INVALID_PATH);
     status = XSP_STATUS_ERROR;
   } else {
-    if (Xsp3Sys[xsp_handle_].features.generation == XspressGen3Mini){
+    // TODO: remove when testing finished
+    bool fallback = false;
+    if (Xsp3Sys[xsp_handle_].features.generation == XspressGen3Mini && fallback == true){
       // TODO: remove this when finished debugging
       LOG4CXX_DEBUG_LEVEL(
         1,

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -165,6 +165,26 @@ int LibXspressWrapper::configure_mca(int num_cards,                 // Number of
     status = XSP_STATUS_ERROR;
     checkErrorCode("xsp3_config", xsp_handle_);
   }
+
+  // Check the clock signal for X3X2 systems
+  if (status == 0 && xsp3_is_xsp3m_plus(0) == 1)
+  {
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 midplane clocks");
+    for (unsigned int card = 0; card < num_cards; card++)
+    {
+      status = xsp3_clocks_setup(
+        xsp_handle_,
+        card,
+        XSP4_CLK_SRC_MIDPLN_LMK61E2,
+        XSP3_CLK_FLAGS_MASTER | XSP3_CLK_FLAGS_NO_DITHER,
+        0
+      );
+      checkErrorCode(status, "Error configuring X3X2 clocks");
+    }
+    status = xsp3_set_sync_mode(xsp_handle_, XSP3_SYNC_MODE(XSP3_SYNC_MIDPLANE), 0, 0);
+    checkErrorCode(status, "Error configuring X3X2 sync mode");
+  }
+
   return status;
 }
 

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -863,11 +863,8 @@ int LibXspressWrapper::get_num_frames_read(int32_t *frames)
   } else {
     if (flags != 0){
       // TODO: check what to do about this permanently - ignore playback under-run which happens on Mk2 a lot?
-      if (flags == Xsp3ErrFlag::Xsp3ErrFlag_Playback)
-      {
-        LOG4CXX_DEBUG_LEVEL(1, logger_, "Ignoring playback underrun");
-        return status;
-      }
+      // If so, should identify whether mark 2 and then check ignore
+      if (flags == Xsp3ErrFlag::Xsp3ErrFlag_Playback) return status;
 
       std::stringstream ss;
       ss << "xsp3_scaler_check_progress_details reported error flags [" << flags << "]";

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1017,8 +1017,7 @@ int LibXspressWrapper::histogram_memcpy(uint32_t *buffer,
     circ_buffer = (bool)(Xsp3Sys[xsp_handle_].run_flags & XSP3_RUN_FLAGS_CIRCULAR_BUFFER);
 
     if (Xsp3Sys[xsp_handle_].features.generation == XspressGen3Mini){
-      xsp_status = xsp3_histogram_read4d(xsp_handle_, buffer, 0, 0, start_chan, tf, num_eng, num_aux, num_chan, num_tf)
-      // xsp_status = xsp3m_histogram_read_frames(xsp_handle_, buffer, 0, start_chan, tf, num_eng, num_chan, num_tf);
+      xsp_status = xsp3_histogram_read4d(xsp_handle_, buffer, 0, 0, start_chan, tf, num_eng, num_aux, num_chan, num_tf);
       if (xsp_status < XSP3_OK){
         checkErrorCode("xsp3_histogram_read_frames", xsp_status);
         status = XSP_STATUS_ERROR;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -169,7 +169,7 @@ int LibXspressWrapper::configure_mca(int num_cards,                 // Number of
   // Check the clock signal for X3X2 systems
   if (status == 0 && xsp3_is_xsp3m_plus(0) == 1)
   {
-    LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 midplane clocks");
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 midplane clock");
     for (unsigned int card = 0; card < num_cards; card++)
     {
       status = xsp3_clocks_setup(
@@ -179,8 +179,9 @@ int LibXspressWrapper::configure_mca(int num_cards,                 // Number of
         XSP3_CLK_FLAGS_MASTER | XSP3_CLK_FLAGS_NO_DITHER,
         0
       );
-      checkErrorCode("Error configuring X3X2 clocks", status);
+      if (status < 0) checkErrorCode("Error configuring X3X2 clocks", status);
     }
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 sync mode");
     status = xsp3_set_sync_mode(xsp_handle_, XSP3_SYNC_MODE(XSP3_SYNC_MIDPLANE), 0, 0);
     checkErrorCode("Error configuring X3X2 sync mode", status);
   }

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1017,7 +1017,8 @@ int LibXspressWrapper::histogram_memcpy(uint32_t *buffer,
     circ_buffer = (bool)(Xsp3Sys[xsp_handle_].run_flags & XSP3_RUN_FLAGS_CIRCULAR_BUFFER);
 
     if (Xsp3Sys[xsp_handle_].features.generation == XspressGen3Mini){
-      xsp_status = xsp3m_histogram_read_frames(xsp_handle_, buffer, 0, start_chan, tf, num_eng, num_chan, num_tf);
+      xsp_status = xsp3_histogram_read4d(xsp_handle_, buffer, 0, 0, start_chan, tf, num_eng, num_chan, num_tf)
+      // xsp_status = xsp3m_histogram_read_frames(xsp_handle_, buffer, 0, start_chan, tf, num_eng, num_chan, num_tf);
       if (xsp_status < XSP3_OK){
         checkErrorCode("xsp3_histogram_read_frames", xsp_status);
         status = XSP_STATUS_ERROR;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1258,7 +1258,7 @@ int LibXspressWrapper::enable_list_mode_resets()
     else
     {
 
-      int current_register_value = 0;
+      u_int32_t current_register_value = 0;
       for (int chan = 0; chan < num_chan; chan++)
       {
         int xsp_status = xsp3_get_chan_cont(xsp_handle_, chan, &current_register_value);

--- a/cpp/control/src/XspressController.cpp
+++ b/cpp/control/src/XspressController.cpp
@@ -774,6 +774,14 @@ void XspressController::configureCommand(OdinData::IpcMessage& config, OdinData:
       // Command failed, return error with any error string
       reply.set_nack(xsp_->getErrorString());
       setError(xsp_->getErrorString());
+    } else {
+      // Configure the clock signals (important for Mk2)
+      status = xsp_->setupClocks();
+    }
+    if (status != XSP_STATUS_OK){
+      // Command failed, return error with any error string
+      reply.set_nack(xsp_->getErrorString());
+      setError(xsp_->getErrorString());
     }
   }
 

--- a/cpp/control/src/XspressController.cpp
+++ b/cpp/control/src/XspressController.cpp
@@ -782,6 +782,14 @@ void XspressController::configureCommand(OdinData::IpcMessage& config, OdinData:
       // Command failed, return error with any error string
       reply.set_nack(xsp_->getErrorString());
       setError(xsp_->getErrorString());
+    } else {
+      // Configure the control register (important for Mk2)
+      status = xsp_->setupControlRegister();
+    }
+    if (status != XSP_STATUS_OK){
+      // Command failed, return error with any error string
+      reply.set_nack(xsp_->getErrorString());
+      setError(xsp_->getErrorString());
     }
   }
 

--- a/cpp/control/src/XspressDAQ.cpp
+++ b/cpp/control/src/XspressDAQ.cpp
@@ -251,6 +251,7 @@ void XspressDAQ::controlTask()
       int32_t frames_read = 0;
       while ((num_frames < total_frames) && acq_running_){
         int status = detector_->get_num_frames_read(&num_frames);
+        LOG4CXX_DEBUG_LEVEL(1, logger_, "Current frame: " << num_frames);
         if (status == XSP_STATUS_OK){
           uint32_t frames_to_read = num_frames - frames_read;
           if (frames_to_read > 0){

--- a/cpp/control/src/XspressDAQ.cpp
+++ b/cpp/control/src/XspressDAQ.cpp
@@ -251,7 +251,6 @@ void XspressDAQ::controlTask()
       int32_t frames_read = 0;
       while ((num_frames < total_frames) && acq_running_){
         int status = detector_->get_num_frames_read(&num_frames);
-        LOG4CXX_DEBUG_LEVEL(1, logger_, "Current frame: " << num_frames);
         if (status == XSP_STATUS_OK){
           uint32_t frames_to_read = num_frames - frames_read;
           if (frames_to_read > 0){

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -162,6 +162,10 @@ int XspressDetector::connect_list_mode()
     xsp_max_channels_,                         // Set the maximum number of channels
     xsp_debug_                                 // Enable debug messages
   );
+
+  // Make sure reset events are enabled for X3X2
+  status |= detector_->enable_list_mode_resets();
+
   if (status == XSP_STATUS_OK){
     // We have a valid handle to set the connected status
     LOG4CXX_INFO(logger_, "Connected to Xspress");

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -215,7 +215,7 @@ int XspressDetector::setupClocks()
 {
   int status = XSP_STATUS_OK;
   if (checkConnected()){
-    status = detector_->setup_clocks(num_cards_);
+    status = detector_->setup_clocks(xsp_num_cards_);
     if (status != XSP_STATUS_OK)
     {
       setErrorString("Failed to configure card clocks");

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -215,7 +215,7 @@ int XspressDetector::setupClocks()
 {
   int status = XSP_STATUS_OK;
   if (checkConnected()){
-    status = detector_->setup_clocks(cards_connected_);
+    status = detector_->setup_clocks(num_cards_);
     if (status != XSP_STATUS_OK)
     {
       setErrorString("Failed to configure card clocks");

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -560,6 +560,7 @@ int XspressDetector::sendSoftwareTrigger()
 {
   int status = XSP_STATUS_OK;
   if (acquiring_){
+    // TODO: BEN: handle what happens in list mode if required
     if (xsp_trigger_mode_ == TM_SOFTWARE){
       status = detector_->histogram_continue(0);
       status |= detector_->histogram_pause(0);

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -211,6 +211,21 @@ int XspressDetector::setupChannels()
   return status;
 }
 
+int XspressDetector::setupClocks()
+{
+  int status = XSP_STATUS_OK;
+  if (checkConnected()){
+    status = detector_->setup_clocks(cards_connected_);
+    if (status != XSP_STATUS_OK)
+    {
+      setErrorString("Failed to configure card clocks");
+    }
+  } else {
+    LOG4CXX_INFO(logger_, "Cannot set up clocks as not connected");
+  }
+  return status;
+}
+
 int XspressDetector::enableDAQ()
 {
   int status = XSP_STATUS_OK;

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -240,7 +240,7 @@ int XspressDetector::setupControlRegister()
   if (checkConnected()){
     if (xsp_mode_ == XSP_MODE_LIST)
     {
-      status = detector_->enable_list_mode_resets(xsp_num_cards_);
+      status = detector_->enable_list_mode_resets();
       if (status != XSP_STATUS_OK)
       {
         setErrorString("Failed to configure list mode resets");

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -162,10 +162,6 @@ int XspressDetector::connect_list_mode()
     xsp_max_channels_,                         // Set the maximum number of channels
     xsp_debug_                                 // Enable debug messages
   );
-
-  // Make sure reset events are enabled for X3X2
-  status |= detector_->enable_list_mode_resets();
-
   if (status == XSP_STATUS_OK){
     // We have a valid handle to set the connected status
     LOG4CXX_INFO(logger_, "Connected to Xspress");
@@ -226,6 +222,33 @@ int XspressDetector::setupClocks()
     }
   } else {
     LOG4CXX_INFO(logger_, "Cannot set up clocks as not connected");
+    status = XSP_STATUS_ERROR;
+  }
+  return status;
+}
+
+/**
+ * @brief Set up the control register values
+ *
+ * - Enables resets if using X3X2 list mode
+ *
+ * @return int Whether we are successful
+ */
+int XspressDetector::setupControlRegister()
+{
+  int status = XSP_STATUS_OK;
+  if (checkConnected()){
+    if (xsp_mode_ == XSP_MODE_LIST)
+    {
+      status = detector_->enable_list_mode_resets(xsp_num_cards_);
+      if (status != XSP_STATUS_OK)
+      {
+        setErrorString("Failed to configure list mode resets");
+      }
+    }
+  } else {
+    LOG4CXX_INFO(logger_, "Cannot set up control register as not connected");
+    status = XSP_STATUS_ERROR;
   }
   return status;
 }

--- a/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
+++ b/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
@@ -1,0 +1,75 @@
+/**
+ * @file X3X2ListModeFrameDecoder.h
+ * @author Ben Bradnick (ben@quantumdetectors.com)
+ * @brief Odin receiver plugin for handling X3X2 list mode TCP data
+ * @date 2024-11-06
+ */
+
+#ifndef INCLUDE_X3X2LISTMODEFRAMEDECODER_H_
+#define INCLUDE_X3X2LISTMODEFRAMEDECODER_H_
+
+#include <iostream>
+#include <stdint.h>
+#include <time.h>
+
+#include "FrameDecoderTCP.h"
+
+namespace FrameReceiver {
+
+namespace X3X2ListModeFrameDecoderDefaults {
+  const int frame_number = -1;
+  const int buffer_id = 0;
+  const size_t max_size = 1000; // maximum size of a frame for dropped buffer, incl. header size
+  const size_t header_size = 100;
+  const int num_buffers = 5;
+} // namespace X3X2ListModeFrameDecoderDefaults
+
+class X3X2ListModeFrameDecoder : public FrameDecoderTCP {
+public:
+  X3X2ListModeFrameDecoder();
+  ~X3X2ListModeFrameDecoder();
+
+  int get_version_major();
+  int get_version_minor();
+  int get_version_patch();
+  std::string get_version_short();
+  std::string get_version_long();
+
+  void monitor_buffers(void);
+  void get_status(const std::string param_prefix,
+                  OdinData::IpcMessage &status_msg);
+
+  void init(LoggerPtr &logger, OdinData::IpcMessage &config_msg);
+  void request_configuration(const std::string param_prefix,
+                             OdinData::IpcMessage &config_reply);
+
+  void *get_next_message_buffer(void);
+  const size_t get_next_message_size(void) const;
+  FrameDecoder::FrameReceiveState process_message(size_t bytes_received);
+
+  const size_t get_frame_buffer_size(void) const;
+  const size_t get_frame_header_size(void) const;
+
+  void reset_statistics(void);
+
+  void *get_packet_header_buffer(void);
+
+  uint32_t get_frame_number(void) const;
+  uint32_t get_packet_number(void) const;
+
+private:
+  boost::shared_ptr<void> frame_buffer_;
+  size_t frames_dropped_;
+  size_t frames_sent_;
+  size_t read_so_far_;
+  int current_frame_number_;
+  int current_frame_buffer_id_;
+  size_t buffer_size_;
+  size_t header_size_;
+  size_t frame_size_;
+  unsigned int num_buffers_;
+  FrameDecoder::FrameReceiveState receive_state_;
+};
+
+} // namespace FrameReceiver
+#endif /* INCLUDE_X3X2LISTMODEFRAMEDECODER_H_ */

--- a/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
+++ b/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
@@ -19,8 +19,8 @@ namespace FrameReceiver {
 namespace X3X2ListModeFrameDecoderDefaults {
   const int frame_number = -1;
   const int buffer_id = 0;
-  const size_t max_size = 1000; // maximum size of a frame for dropped buffer, incl. header size
-  const size_t header_size = 100;
+  const size_t max_size = 8192; // Each TCP frame is 8192 bytes of 4096 16 bit words
+  const size_t header_size = 30; // Header is first and should contain 15 words
   const int num_buffers = 5;
 } // namespace X3X2ListModeFrameDecoderDefaults
 

--- a/cpp/data/frameReceiver/include/XspressListModeFrameDecoder.h
+++ b/cpp/data/frameReceiver/include/XspressListModeFrameDecoder.h
@@ -1,3 +1,10 @@
+/**
+ * @file XspressListModeFrameDecoder.h
+ * @author Alan Greer
+ * @brief This decoder is used to handle list mode events for Xspress 4
+ * @date 2025-01-02
+ */
+
 #ifndef SRC_XSPRESSLISTMODEDECODER_H
 #define SRC_XSPRESSLISTMODEDECODER_H
 

--- a/cpp/data/frameReceiver/src/CMakeLists.txt
+++ b/cpp/data/frameReceiver/src/CMakeLists.txt
@@ -10,6 +10,10 @@ target_link_libraries(XspressFrameDecoder ${ODINDATA_LIBRARIES} ${Boost_LIBRARIE
 add_library(XspressListModeFrameDecoder SHARED XspressListModeFrameDecoder.cpp XspressListModeFrameDecoderLib.cpp)
 target_link_libraries(XspressListModeFrameDecoder ${ODINDATA_LIBRARIES} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
 
+# Add library for xspress X3X2 list mode decoder
+add_library(X3X2ListModeFrameDecoder SHARED X3X2ListModeFrameDecoder.cpp X3X2ListModeFrameDecoderLib.cpp)
+target_link_libraries(X3X2ListModeFrameDecoder ${ODINDATA_LIBRARIES} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
+
 
 install(TARGETS XspressFrameDecoder
         RUNTIME DESTINATION bin
@@ -21,3 +25,7 @@ install(TARGETS XspressListModeFrameDecoder
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
+install(TARGETS X3X2ListModeFrameDecoder
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)

--- a/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
+++ b/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
@@ -148,21 +148,21 @@ void X3X2ListModeFrameDecoder::get_status(const std::string param_prefix,
 }
 
 int X3X2ListModeFrameDecoder::get_version_major() {
-  return ODIN_DATA_VERSION_MAJOR;
+  return XSPRESS_DETECTOR_VERSION_MAJOR;
 }
 
 int X3X2ListModeFrameDecoder::get_version_minor() {
-  return ODIN_DATA_VERSION_MINOR;
+  return XSPRESS_DETECTOR_VERSION_MINOR;
 }
 
 int X3X2ListModeFrameDecoder::get_version_patch() {
-  return ODIN_DATA_VERSION_PATCH;
+  return XSPRESS_DETECTOR_VERSION_PATCH;
 }
 
 std::string X3X2ListModeFrameDecoder::get_version_short() {
-  return ODIN_DATA_VERSION_STR_SHORT;
+  return XSPRESS_DETECTOR_VERSION_STR_SHORT;
 }
 
 std::string X3X2ListModeFrameDecoder::get_version_long() {
-  return ODIN_DATA_VERSION_STR;
+  return XSPRESS_DETECTOR_VERSION_STR;
 }

--- a/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
+++ b/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
@@ -1,0 +1,168 @@
+/**
+ * @file X3X2ListModeFrameDecoder.cpp
+ * @author Ben Bradnick (ben@quantumdetectors.com)
+ * @brief Odin receiver plugin for handling X3X2 list mode TCP data
+ * @date 2024-11-06
+ */
+
+
+#include "X3X2ListModeFrameDecoder.h"
+#include "gettime.h"
+#include "version.h"
+#include <algorithm>
+#include <bitset>
+#include <boost/algorithm/string.hpp>
+#include <sstream>
+#include <string.h>
+#include <unistd.h>
+
+using namespace FrameReceiver;
+
+X3X2ListModeFrameDecoder::X3X2ListModeFrameDecoder()
+    : FrameDecoderTCP(),
+      current_frame_number_(X3X2ListModeFrameDecoderDefaults::frame_number),
+      current_frame_buffer_id_(X3X2ListModeFrameDecoderDefaults::buffer_id),
+      header_size_(X3X2ListModeFrameDecoderDefaults::header_size),
+      frame_size_(X3X2ListModeFrameDecoderDefaults::max_size),
+      num_buffers_(X3X2ListModeFrameDecoderDefaults::num_buffers),
+      frames_dropped_(0), frames_sent_(0), read_so_far_(0),
+      receive_state_(FrameDecoder::FrameReceiveStateEmpty) {
+  this->logger_ = Logger::getLogger("FR.X3X2ListModeFrameDecoder");
+  LOG4CXX_INFO(logger_, "X3X2ListModeFrameDecoder version "
+                            << this->get_version_long() << " loaded");
+  // buffer can fit 5 frames by default
+  buffer_size_ = num_buffers_ * frame_size_;
+  frame_buffer_.reset(new char[buffer_size_]);
+}
+
+//! Destructor for X3X2ListModeFrameDecoder
+X3X2ListModeFrameDecoder::~X3X2ListModeFrameDecoder() {}
+
+/**
+ * Initialises the frame decoder
+ *
+ * \param[in] logger The logger
+ * \param[in] config_msg The config parameters to initialise with
+ */
+void X3X2ListModeFrameDecoder::init(LoggerPtr &logger,
+                                OdinData::IpcMessage &config_msg) {}
+
+void X3X2ListModeFrameDecoder::reset_statistics() {
+  FrameDecoderTCP::reset_statistics();
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "X3X2ListModeFrameDecoder resetting statistics");
+  current_frame_number_ = X3X2ListModeFrameDecoderDefaults::frame_number;
+  current_frame_buffer_id_ = X3X2ListModeFrameDecoderDefaults::buffer_id;
+  frames_sent_ = 0;
+  read_so_far_ = 0;
+}
+
+//! Handle a request for the current decoder configuration.
+//!
+//! This method handles a request for the current decoder configuration, by
+//! populating an IPCMessage with all current configuration parameters.
+//!
+//! \param[in] param_prefix: string prefix to add to each parameter populated in
+//! reply \param[in,out] config_reply: IpcMessage to populate with current
+//! decoder parameters
+//!
+
+void X3X2ListModeFrameDecoder::request_configuration(
+    const std::string param_prefix, OdinData::IpcMessage &config_reply) {
+  // Call the base class method to populate parameters
+  FrameDecoder::request_configuration(param_prefix, config_reply);
+  config_reply.set_param(param_prefix + "frame_size", frame_size_);
+}
+
+/**
+ * Gets the buffer to use to store the next message, allocating one if necessary
+ *
+ * \return Pointer to the current buffer
+ */
+void *X3X2ListModeFrameDecoder::get_next_message_buffer(void) {
+  // only increment buffer when frame is complete
+  if (receive_state_ != FrameDecoder::FrameReceiveStateIncomplete) {
+    // get id in buffer circularly
+    if (current_frame_buffer_id_ + 1 >= num_buffers_)
+      current_frame_buffer_id_ = 0;
+    else
+      current_frame_buffer_id_++;
+  }
+  current_raw_buffer_ =
+      buffer_manager_->get_buffer_address(current_frame_buffer_id_);
+  return static_cast<void *>(static_cast<char *>(current_raw_buffer_) +
+                             read_so_far_);
+}
+
+//! Get the size of the frame buffers required for current operation mode.
+//!
+//! This method returns the frame buffer size required for the current operation
+//! mode.
+//!
+//! \return size of frame buffer in bytes
+//!
+const size_t X3X2ListModeFrameDecoder::get_frame_buffer_size(void) const {
+  return buffer_size_;
+}
+
+//! Get the size of the frame header.
+//!
+//! This method returns the size of the frame header used by the decoder.
+//!
+//! \return size of the frame header in bytes
+const size_t X3X2ListModeFrameDecoder::get_frame_header_size(void) const {
+  return header_size_;
+}
+
+/**
+ * Processes the message in the current buffer
+ *
+ * \param[in] bytes_received The number of bytes received
+ * \return The state after processing
+ */
+FrameDecoder::FrameReceiveState
+X3X2ListModeFrameDecoder::process_message(size_t bytes_received) {
+  LOG4CXX_INFO(logger_, "Processing " << bytes_received << " bytes");
+  if (read_so_far_ + bytes_received == frame_size_) {
+    read_so_far_ = 0;
+    return FrameDecoder::FrameReceiveStateComplete;
+  } else if (read_so_far_ + bytes_received < frame_size_) {
+    read_so_far_ += bytes_received;
+    // track how many bytes have been received out of the
+    // required total and attempt to complete by yielding control back to Rx
+    // thread.
+    return FrameDecoder::FrameReceiveStateIncomplete;
+  } else
+    throw "Not Implemented: Can not handle case when too many bytes received";
+}
+
+const size_t X3X2ListModeFrameDecoder::get_next_message_size(void) const {
+  return frame_size_ - read_so_far_;
+}
+
+void X3X2ListModeFrameDecoder::monitor_buffers(void) {}
+
+void X3X2ListModeFrameDecoder::get_status(const std::string param_prefix,
+                                      OdinData::IpcMessage &status_msg) {
+  status_msg.set_param(param_prefix + "name",
+                       std::string("X3X2ListModeFrameDecoder"));
+}
+
+int X3X2ListModeFrameDecoder::get_version_major() {
+  return ODIN_DATA_VERSION_MAJOR;
+}
+
+int X3X2ListModeFrameDecoder::get_version_minor() {
+  return ODIN_DATA_VERSION_MINOR;
+}
+
+int X3X2ListModeFrameDecoder::get_version_patch() {
+  return ODIN_DATA_VERSION_PATCH;
+}
+
+std::string X3X2ListModeFrameDecoder::get_version_short() {
+  return ODIN_DATA_VERSION_STR_SHORT;
+}
+
+std::string X3X2ListModeFrameDecoder::get_version_long() {
+  return ODIN_DATA_VERSION_STR;
+}

--- a/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoderLib.cpp
+++ b/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoderLib.cpp
@@ -1,0 +1,19 @@
+/**
+ * @file X3X2ListModeFrameDecoderLib.cpp
+ * @author Ben Bradnick (ben@quantumdetectors.com)
+ * @brief Registrar for X3X2 list mode receiver plugin
+ * @date 2024-11-06
+ */
+
+#include "X3X2ListModeFrameDecoder.h"
+#include "ClassLoader.h"
+
+namespace FrameReceiver
+{
+  /**
+   * Registration of this decoder through the ClassLoader.  This macro
+   * registers the class without needing to worry about name mangling
+   */
+  REGISTER(FrameDecoder, X3X2ListModeFrameDecoder, "X3X2ListModeFrameDecoder");
+}
+// namespace FrameReceiver

--- a/python/src/xspress_detector/control/detector.py
+++ b/python/src/xspress_detector/control/detector.py
@@ -877,9 +877,9 @@ class XspressDetector(object):
         resp = await self._async_client.send_recv(self.configuration.get())
         # resp = await self._put(MessageType.CONFIG, XspressDetectorStr.CONFIG_CONFIG_PATH, self.settings_paths[mode])
         resp = await self._put(MessageType.CMD, XspressDetectorStr.CMD_DISCONNECT, 1)
-        # TODO: Ben - check this is correct for X3X2 units
+        # TODO: Ben - check this is correct for X3X2 units (i.e. ignore marker channels)
         # If so then we are going to need to work out whether the Xspress system is a Mk2 or not (or non-X?)
-        chans = self.mca_channels if mode == XSPRESS_MODE_MCA else self.mca_channels + 1
+        chans = self.mca_channels #  if mode == XSPRESS_MODE_MCA else self.mca_channels + 1
         await self._put(
             MessageType.CONFIG, XspressDetectorStr.CONFIG_MAX_CHANNELS, chans
         )

--- a/python/src/xspress_detector/control/detector.py
+++ b/python/src/xspress_detector/control/detector.py
@@ -879,7 +879,7 @@ class XspressDetector(object):
         resp = await self._put(MessageType.CMD, XspressDetectorStr.CMD_DISCONNECT, 1)
         # TODO: Ben - check this is correct for X3X2 units
         # If so then we are going to need to work out whether the Xspress system is a Mk2 or not (or non-X?)
-        chans = self.mca_channels if mode == XSPRESS_MODE_MCA else self.mca_channels + int(2*self.num_cards)
+        chans = self.mca_channels if mode == XSPRESS_MODE_MCA else self.mca_channels + 1
         await self._put(
             MessageType.CONFIG, XspressDetectorStr.CONFIG_MAX_CHANNELS, chans
         )

--- a/python/src/xspress_detector/control/detector.py
+++ b/python/src/xspress_detector/control/detector.py
@@ -827,14 +827,12 @@ class XspressDetector(object):
             configs = [
                 {
                     "rx_ports": ",".join([str(p) for p in ports]),
-                    "rx_type": "udp",
-                    "decoder_type": "XspressListMode",
+                    "rx_type": "tcp",
+                    "decoder_type": "X3X2ListMode",
                     "rx_address": ip,
                     "rx_recv_buffer_size": 30000000,
                 }
-                for ip, ports in ListModeIPPortGen(
-                    self.num_chan_per_process_list, self.num_process_list
-                )
+                for ip, ports in [("192.168.0.2", [30125]), ("192.168.0.3", [30125])]
             ]
         elif mode == XSPRESS_MODE_MCA:
             configs = [

--- a/python/src/xspress_detector/control/detector.py
+++ b/python/src/xspress_detector/control/detector.py
@@ -870,16 +870,16 @@ class XspressDetector(object):
 
         # This seems to help when dealing with detectors that don't have 8 channels.
         # Apparently when the detector has a number of channels different from that defined in 'DEFAULT_MAX_CHANNELS',
-        # at XspressDetector.h, we have some problems when trying to connect to it straigh away using the reconfigure button.
+        # at XspressDetector.h, we have some problems when trying to connect to it straight away using the reconfigure button.
         await self.reset()
         await asyncio.sleep(FR_INIT_TIME[mode])
 
         resp = await self._async_client.send_recv(self.configuration.get())
         # resp = await self._put(MessageType.CONFIG, XspressDetectorStr.CONFIG_CONFIG_PATH, self.settings_paths[mode])
         resp = await self._put(MessageType.CMD, XspressDetectorStr.CMD_DISCONNECT, 1)
-        # TODO: Ben - check this is correct for X3X2 units (i.e. don't add an additional MCA channel)
+        # TODO: Ben - check this is correct for X3X2 units
         # If so then we are going to need to work out whether the Xspress system is a Mk2 or not (or non-X?)
-        chans = self.mca_channels # if mode == XSPRESS_MODE_MCA else self.mca_channels + 1
+        chans = self.mca_channels if mode == XSPRESS_MODE_MCA else self.mca_channels + int(2*self.num_cards)
         await self._put(
             MessageType.CONFIG, XspressDetectorStr.CONFIG_MAX_CHANNELS, chans
         )
@@ -951,6 +951,7 @@ class XspressDetector(object):
         self.logger.critical(debug_method())
         self.max_channels = max_channels
         self.mca_channels = max_channels
+        self.num_cards = num_cards
         self.max_spectra = max_spectra
         self.run_flags = run_flags
         self.fr_clients = [

--- a/python/src/xspress_detector/control/detector.py
+++ b/python/src/xspress_detector/control/detector.py
@@ -877,7 +877,9 @@ class XspressDetector(object):
         resp = await self._async_client.send_recv(self.configuration.get())
         # resp = await self._put(MessageType.CONFIG, XspressDetectorStr.CONFIG_CONFIG_PATH, self.settings_paths[mode])
         resp = await self._put(MessageType.CMD, XspressDetectorStr.CMD_DISCONNECT, 1)
-        chans = self.mca_channels if mode == XSPRESS_MODE_MCA else self.mca_channels + 1
+        # TODO: Ben - check this is correct for X3X2 units (i.e. don't add an additional MCA channel)
+        # If so then we are going to need to work out whether the Xspress system is a Mk2 or not (or non-X?)
+        chans = self.mca_channels # if mode == XSPRESS_MODE_MCA else self.mca_channels + 1
         await self._put(
             MessageType.CONFIG, XspressDetectorStr.CONFIG_MAX_CHANNELS, chans
         )

--- a/python/src/xspress_detector/control/detector.py
+++ b/python/src/xspress_detector/control/detector.py
@@ -824,6 +824,11 @@ class XspressDetector(object):
 
     async def configure_frs(self, mode: int):
         if mode == XSPRESS_MODE_LIST:
+            # One ADC card per process pair (one TCP connection each)
+            # TODO: replace 30127 (the scalars socket) for 30125
+            # (the actual event socket when ready)
+            ip_and_ports = [(f"192.168.0.{card_num+1}", [30127]) for card_num in range(1, self.num_cards+1)]
+            self.logger.info(f"Connecting to list mode sockets {ip_and_ports}")
             configs = [
                 {
                     "rx_ports": ",".join([str(p) for p in ports]),
@@ -832,7 +837,7 @@ class XspressDetector(object):
                     "rx_address": ip,
                     "rx_recv_buffer_size": 30000000,
                 }
-                for ip, ports in [("192.168.0.2", [30125]), ("192.168.0.3", [30125])]
+                for ip, ports in ip_and_ports
             ]
         elif mode == XSPRESS_MODE_MCA:
             configs = [

--- a/python/src/xspress_detector/control/fp_xspress_adapter.py
+++ b/python/src/xspress_detector/control/fp_xspress_adapter.py
@@ -189,4 +189,4 @@ class FPXspressAdapter(FrameProcessorAdapter):
                     "config/hdf/dataset/data",
                     "config/hdf/dataset/{}".format(dataset) + "/{}".format(client),
                 )
-                super(FPCompressionAdapter.__base__, self).put(dataset_path, request)
+                super(FrameProcessorAdapter.__base__, self).put(dataset_path, request)

--- a/python/src/xspress_detector/control/fp_xspress_adapter.py
+++ b/python/src/xspress_detector/control/fp_xspress_adapter.py
@@ -10,7 +10,7 @@ import asyncio
 import time
 
 from odin_data.control.odin_data_adapter import OdinDataAdapter
-from odin_data.control.fp_compression_adapter import FPCompressionAdapter
+from odin_data.control.frame_processor_adapter import FrameProcessorAdapter
 from odin.adapters.adapter import (
     ApiAdapterResponse,
     request_types,
@@ -27,7 +27,7 @@ def bool_from_string(value):
     return bool_value
 
 
-class FPXspressAdapter(FPCompressionAdapter):
+class FPXspressAdapter(FrameProcessorAdapter):
     """
     FPXspressAdapter class
 


### PR DESCRIPTION
Overview
---------

This is the first release with working MCA mode tested with a 4 channel Xspress 3 MK2.

Test system setup:

- 4 channel Xspress 3 Mini Mk 2 (2 cards)
- CentOS Stream 9
- 2 frame processor/receiver pairs (i.e. 1 per card)

Tested:

1. Simple MCA acquisitions with internal triggering and Odin file saving to HDF5 and Scan Engine providing fake events
2. Benchmarked MCA acquisitions to 4kHz on Xspress mini Mk1 system
3. Simple list mode acquisitions with internal triggering and Python list mode listeners writing binary data to files (and then decoding after acquisition) - ~6 million events per second from Scan Engine

Changelog
-----------

Added:

- WIP of X3X2 list mode decoder plugin

Changed:

- C++ control server
  - now configures X3X2 clocks
  - now enables resets in list mode
  - Xspress library configure call explicitly requests list readout mode
- Python control server
  - requests X3X2 list mode decoder plugin on configure to list mode
  - changed number of channels used in list mode
  - changed frame receiver IP/port configuration (currently listens to
    scalars socket to leave event TCP/IP socket free for Python)

Fixed:

- Now use Xspress library method `xsp3_histogram_read4d` when reading X3X2 MCA
  data
- Set num_cards when detector is configured in control server

