### PR TITLE
Change number of list mode processes to be equivalent to MCA mode

### DIFF
--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -4,13 +4,14 @@ Change log
 Changes made by Quantum Detectors to this repository are recorded below.
 
 
-Unreleased
-----------
+0.5.0+qd0.3
+-----------
 
 Changed:
 
 - Changed the number of processes used in list mode and MCA mode to be the same
-  (relevant for Mk2 Xspress)
+  for support with X3X2 systems.
+- Some tidy up of unused imports
 
 
 0.5.0+qd0.2

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,6 +3,16 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
+
+Unreleased
+----------
+
+Changed:
+
+- Changed the number of processes used in list mode and MCA mode to be the same
+  (relevant for Mk2 Xspress)
+
+
 0.5.0+qd0.2
 -----------
 

--- a/python/src/xspress_detector/control/adapter.py
+++ b/python/src/xspress_detector/control/adapter.py
@@ -40,7 +40,9 @@ class XspressAdapter(AsyncApiAdapter):
             endpoint = self.options['endpoint']
             ip, port = endpoint.split(":")
             num_process = int(self.options["num_process"])
-            num_process_list = max(2,num_process-1) if num_process >=2 else 1
+            # For X3X2 the number of list mode processes is the same as in MCA mode
+            # TODO: handle with a config flag so we don't break compatibility with Xspress 4
+            num_process_list = num_process
             self.detector = XspressDetector(ip, port, num_process_mca=num_process, num_process_list=num_process_list)
             logging.info(f"instatiated XspressDetector with ip = {ip} and port {port}\n num_process/list = {num_process}/{num_process_list}")
 

--- a/python/src/xspress_detector/control/client.py
+++ b/python/src/xspress_detector/control/client.py
@@ -7,7 +7,7 @@ import asyncio
 from odin_data.control.ipc_message import IpcMessage
 from zmq.eventloop.zmqstream import ZMQStream
 from zmq.utils.monitor import parse_monitor_message
-from zmq.utils.strtypes import unicode, cast_bytes, cast_unicode
+from zmq.utils.strtypes import cast_bytes, cast_unicode
 
 
 DEFAULT_TIMEOUT = 5

--- a/python/src/xspress_detector/control/fp_xspress_adapter.py
+++ b/python/src/xspress_detector/control/fp_xspress_adapter.py
@@ -3,11 +3,8 @@ Created on March 2022
 
 :author: Alan Greer
 """
-import json
 import logging
 import os
-import asyncio
-import time
 
 from odin_data.control.odin_data_adapter import OdinDataAdapter
 from odin_data.control.frame_processor_adapter import FrameProcessorAdapter
@@ -17,7 +14,7 @@ from odin.adapters.adapter import (
     response_types,
 )
 from tornado import escape
-from tornado.escape import json_encode, json_decode
+from tornado.escape import json_decode
 
 
 def bool_from_string(value):

--- a/python/src/xspress_detector/control/live_view_merge.py
+++ b/python/src/xspress_detector/control/live_view_merge.py
@@ -1,12 +1,7 @@
 import zmq
-import struct
-import numpy as np
 import json
 import argparse
-from datetime import datetime
 import logging
-
-
 
 
 class LiveViewCombiner(object):


### PR DESCRIPTION
Change the number of list mode processes to be equivalent in MCA and list mode. We currently configure a fixed number of FR/FP pairs - 1 per ADC card in a Mk2 system.