### PR TITLE
Feature/list mode separate datasets

### DIFF
--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,6 +3,19 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
+Unreleased
+----------
+
+Changed:
+
+- Separated out X3X2 list mode datasets to 1 dataset per event field. The memory
+  block has been split up into a base class and derived classes to manage the
+  different datatypes.
+- Changed how the X3X2 list mode plugin tracks acquisition completion
+  as we receive multiple events with the end of frame marker set. Now
+  use a map to track individual channel completion. The additional
+  events are currently ignored.
+
 
 0.5.0+qd0.3
 -----------

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,18 +3,33 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
-Unreleased
-----------
+
+0.5.0+qd0.4
+-----------
 
 Changed:
 
 - Separated out X3X2 list mode datasets to 1 dataset per event field. The memory
   block has been split up into a base class and derived classes to manage the
-  different datatypes.
+  different datatypes used for each field. The datasets created are:
+
+  - chX_time_frame (uint64)
+  - chX_time_stamp (uint64)
+  - chX_event_height (uint16)
+  - chX_reset_flag (uint8)
+
 - Changed how the X3X2 list mode plugin tracks acquisition completion
   as we receive multiple events with the end of frame marker set. Now
   use a map to track individual channel completion. The additional
   events are currently ignored.
+- The X3X2 list mode processor plugin now sets the size of each memory
+  block based on number of events stored (versus using bytes). The `frame_size`
+  option under `xspress-list` in the JSON configuration file is used to define
+  the number of events per memory block frame.
+
+Fixed:
+
+- Fixed issue with parsing the time frame bits in the X3X2 list mode plugin
 
 
 0.5.0+qd0.3

--- a/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
@@ -81,6 +81,18 @@ namespace FrameProcessor
     boost::shared_ptr <Frame> add_event_height(uint16_t event_height);
   };
 
+  /**
+   * Specific class for managing event reset flag memory blocks
+   */
+  class X3X2ListModeResetFlagMemoryBlock :  public X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeResetFlagMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeResetFlagMemoryBlock();
+
+    boost::shared_ptr <Frame> add_reset_flag(uint8_t reset_flag);
+  };
+
 }
 
 #endif //SRC_X3X2LISTMODEMEMORYBLOCK_H

--- a/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
@@ -1,0 +1,46 @@
+#ifndef SRC_X3X2LISTMODEMEMORYBLOCK_H
+#define SRC_X3X2LISTMODEMEMORYBLOCK_H
+
+#include <log4cxx/logger.h>
+#include <log4cxx/basicconfigurator.h>
+#include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/helpers/exception.h>
+
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+
+#include "FrameProcessorPlugin.h"
+#include "gettime.h"
+
+namespace FrameProcessor
+{
+
+  class X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeMemoryBlock();
+    void set_size(uint32_t bytes);
+    void reallocate();
+    void reset();
+    void reset_frame_count();
+    boost::shared_ptr <Frame> add_event(uint64_t time_stamp);
+    boost::shared_ptr <Frame> to_frame();
+    boost::shared_ptr <Frame> flush();
+
+  private:
+    void *ptr_;
+    std::string name_;
+    uint32_t num_bytes_;
+    uint32_t filled_size_;  // Filled size in bytes
+    uint32_t frame_count_;
+
+    const uint32_t num_bytes_per_event_ = 8;
+
+    /** Pointer to logger */
+    LoggerPtr logger_;
+  };
+
+}
+
+#endif //SRC_X3X2LISTMODEMEMORYBLOCK_H

--- a/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
@@ -22,7 +22,7 @@ namespace FrameProcessor
   class X3X2ListModeMemoryBlock
   {
   public:
-    X3X2ListModeMemoryBlock(const std::string& name, uint32_t num_bytes_per_event);
+    X3X2ListModeMemoryBlock(const std::string& name, DataType data_type, uint32_t num_bytes_per_event);
     virtual ~X3X2ListModeMemoryBlock();
     void set_size(uint32_t bytes);
     void reallocate();
@@ -38,10 +38,23 @@ namespace FrameProcessor
     uint32_t filled_size_;
     uint32_t frame_count_;
 
+    DataType data_type_;
     uint32_t num_bytes_per_event_;
 
     /** Pointer to logger */
     LoggerPtr logger_;
+  };
+
+  /**
+   * Specific class for managing timeframe memory blocks
+   */
+  class X3X2ListModeTimeframeMemoryBlock :  public X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeTimeframeMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeTimeframeMemoryBlock();
+
+    boost::shared_ptr <Frame> add_timeframe(uint64_t timeframe);
   };
 
   /**
@@ -54,6 +67,18 @@ namespace FrameProcessor
     virtual ~X3X2ListModeTimestampMemoryBlock();
 
     boost::shared_ptr <Frame> add_timestamp(uint64_t timestamp);
+  };
+
+  /**
+   * Specific class for managing event height memory blocks
+   */
+  class X3X2ListModeEventHeightMemoryBlock :  public X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeEventHeightMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeEventHeightMemoryBlock();
+
+    boost::shared_ptr <Frame> add_event_height(uint16_t event_height);
   };
 
 }

--- a/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
@@ -15,30 +15,45 @@ using namespace log4cxx::helpers;
 namespace FrameProcessor
 {
 
+  /**
+   * Generic class for managing a block of memory containing a single field
+   * of list mode data.
+   */
   class X3X2ListModeMemoryBlock
   {
   public:
-    X3X2ListModeMemoryBlock(const std::string& name);
+    X3X2ListModeMemoryBlock(const std::string& name, uint32_t num_bytes_per_event);
     virtual ~X3X2ListModeMemoryBlock();
     void set_size(uint32_t bytes);
     void reallocate();
     void reset();
     void reset_frame_count();
-    boost::shared_ptr <Frame> add_event(uint64_t time_stamp);
     boost::shared_ptr <Frame> to_frame();
     boost::shared_ptr <Frame> flush();
 
-  private:
+  protected:
     void *ptr_;
     std::string name_;
     uint32_t num_bytes_;
-    uint32_t filled_size_;  // Filled size in bytes
+    uint32_t filled_size_;
     uint32_t frame_count_;
 
-    const uint32_t num_bytes_per_event_ = 8;
+    uint32_t num_bytes_per_event_;
 
     /** Pointer to logger */
     LoggerPtr logger_;
+  };
+
+  /**
+   * Specific class for managing timestamp memory blocks
+   */
+  class X3X2ListModeTimestampMemoryBlock :  public X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeTimestampMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeTimestampMemoryBlock();
+
+    boost::shared_ptr <Frame> add_timestamp(uint64_t timestamp);
   };
 
 }

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -50,10 +50,12 @@ namespace FrameProcessor
     void clear_timeframe_memory_blocks();
     void clear_timestamp_memory_blocks();
     void clear_event_height_memory_blocks();
+    void clear_reset_flag_memory_blocks();
 
     void flush_timeframe_memory_blocks();
     void flush_timestamp_memory_blocks();
     void flush_event_height_memory_blocks();
+    void flush_reset_flag_memory_blocks();
 
     void setup_channel_memory_blocks(uint32_t channel);
 
@@ -66,16 +68,17 @@ namespace FrameProcessor
     uint32_t num_channels_;
     uint32_t channel_offset_;
 
+    // Acquisition properties
     uint32_t num_time_frames_;
-
     std::map<uint32_t, bool> completed_channels_;
     bool acquisition_complete_;
-
     uint64_t num_events_;
 
+    // Memory blocks for event fields
     std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock> > timeframe_memory_ptrs_;
     std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimestampMemoryBlock> > timestamp_memory_ptrs_;
     std::map<uint32_t, boost::shared_ptr<X3X2ListModeEventHeightMemoryBlock> > event_height_memory_ptrs_;
+    std::map<uint32_t, boost::shared_ptr<X3X2ListModeResetFlagMemoryBlock> > reset_flag_memory_ptrs_;
 
     std::map<uint32_t, std::vector<uint32_t> > packet_headers_;
 

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -45,7 +45,18 @@ namespace FrameProcessor
     void set_channels(std::vector<uint32_t> channels);
     void set_frame_size(uint32_t num_bytes);
     void setup_memory_allocation();
-        
+
+    // Memory blocks
+    void clear_timeframe_memory_blocks();
+    void clear_timestamp_memory_blocks();
+    void clear_event_height_memory_blocks();
+
+    void flush_timeframe_memory_blocks();
+    void flush_timestamp_memory_blocks();
+    void flush_event_height_memory_blocks();
+
+    void setup_channel_memory_blocks(uint32_t channel);
+
     // Plugin interface
     void status(OdinData::IpcMessage& status);
     void process_frame(boost::shared_ptr <Frame> frame);
@@ -56,10 +67,16 @@ namespace FrameProcessor
     uint32_t channel_offset_;
 
     uint32_t num_time_frames_;
-    uint32_t num_completed_channels_;
+
+    std::map<uint32_t, bool> completed_channels_;
     bool acquisition_complete_;
 
-    std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimestampMemoryBlock> > memory_ptrs_;
+    uint64_t num_events_;
+
+    std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock> > timeframe_memory_ptrs_;
+    std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimestampMemoryBlock> > timestamp_memory_ptrs_;
+    std::map<uint32_t, boost::shared_ptr<X3X2ListModeEventHeightMemoryBlock> > event_height_memory_ptrs_;
+
     std::map<uint32_t, std::vector<uint32_t> > packet_headers_;
 
     static const std::string CONFIG_CHANNELS;

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -59,7 +59,7 @@ namespace FrameProcessor
     uint32_t num_completed_channels_;
     bool acquisition_complete_;
 
-    std::map<uint32_t, boost::shared_ptr<X3X2ListModeMemoryBlock> > memory_ptrs_;
+    std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimestampMemoryBlock> > memory_ptrs_;
     std::map<uint32_t, std::vector<uint32_t> > packet_headers_;
 
     static const std::string CONFIG_CHANNELS;

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -82,6 +82,8 @@ namespace FrameProcessor
 
     uint32_t num_time_frames_;
     uint32_t num_completed_channels_;
+    std::vector<bool> completed_channels;
+    bool acquisition_complete_;
 
     std::map<uint32_t, boost::shared_ptr<X3X2ListModeMemoryBlock> > memory_ptrs_;
     std::map<uint32_t, std::vector<uint32_t> > packet_headers_;

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -82,7 +82,6 @@ namespace FrameProcessor
 
     uint32_t num_time_frames_;
     uint32_t num_completed_channels_;
-    std::vector<bool> completed_channels;
     bool acquisition_complete_;
 
     std::map<uint32_t, boost::shared_ptr<X3X2ListModeMemoryBlock> > memory_ptrs_;

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -26,7 +26,7 @@ namespace FrameProcessor
     void reallocate();
     void reset();
     void reset_frame_count();
-    boost::shared_ptr <Frame> add_event(uint64_t time_frame, uint64_t time_stamp, uint64_t event_height);
+    boost::shared_ptr <Frame> add_event(uint64_t time_stamp);
     boost::shared_ptr <Frame> to_frame();
     boost::shared_ptr <Frame> flush();
 

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -43,7 +43,7 @@ namespace FrameProcessor
     void reset_acquisition();
     void flush_close_acquisition();
     void set_channels(std::vector<uint32_t> channels);
-    void set_frame_size(uint32_t num_bytes);
+    void set_frame_size(uint32_t num_events);
     void setup_memory_allocation();
 
     // Memory blocks
@@ -65,7 +65,7 @@ namespace FrameProcessor
     void status(OdinData::IpcMessage& status);
     void process_frame(boost::shared_ptr <Frame> frame);
 
-    uint32_t frame_size_bytes_;
+    uint32_t frame_size_events_;
     std::vector<uint32_t> channels_;
     uint32_t num_channels_;
     uint32_t channel_offset_;

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -59,6 +59,8 @@ namespace FrameProcessor
 
     void setup_channel_memory_blocks(uint32_t channel);
 
+    void reset_channel_statistics();
+
     // Plugin interface
     void status(OdinData::IpcMessage& status);
     void process_frame(boost::shared_ptr <Frame> frame);
@@ -70,9 +72,11 @@ namespace FrameProcessor
 
     // Acquisition properties
     uint32_t num_time_frames_;
-    std::map<uint32_t, bool> completed_channels_;
     bool acquisition_complete_;
-    uint64_t num_events_;
+
+    // Tracking per channel
+    std::map<uint32_t, bool> completed_channels_;
+    std::map<uint32_t, uint64_t> num_events_;
 
     // Memory blocks for event fields
     std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock> > timeframe_memory_ptrs_;

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -12,36 +12,11 @@ using namespace log4cxx::helpers;
 
 #include "FrameProcessorPlugin.h"
 #include "XspressDefinitions.h"
+#include "X3X2ListModeMemoryBlocks.h"
 #include "gettime.h"
 
 namespace FrameProcessor
 {
-
-  class X3X2ListModeMemoryBlock
-  {
-  public:
-    X3X2ListModeMemoryBlock(const std::string& name);
-    virtual ~X3X2ListModeMemoryBlock();
-    void set_size(uint32_t bytes);
-    void reallocate();
-    void reset();
-    void reset_frame_count();
-    boost::shared_ptr <Frame> add_event(uint64_t time_stamp);
-    boost::shared_ptr <Frame> to_frame();
-    boost::shared_ptr <Frame> flush();
-
-  private:
-    void *ptr_;
-    std::string name_;
-    uint32_t num_bytes_;
-    uint32_t filled_size_;  // Filled size in bytes
-    uint32_t frame_count_;
-
-    const uint32_t num_bytes_per_event_ = 24;
-
-    /** Pointer to logger */
-    LoggerPtr logger_;
-  };
 
   class X3X2ListModeProcessPlugin : public FrameProcessorPlugin 
   {

--- a/cpp/data/frameProcessor/src/CMakeLists.txt
+++ b/cpp/data/frameProcessor/src/CMakeLists.txt
@@ -3,15 +3,15 @@ set(CMAKE_INCLUDE_CURRENT_DIR on)
 include_directories(${FRAMEPROCESSOR_DIR}/include ${ODINDATA_INCLUDE_DIRS} ${HDF5_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS})
 
 # Add library for Xspress process plugin
-add_library(XspressProcessPlugin SHARED XspressProcessPlugin.cpp XspressProcessPluginLib.cpp)
+add_library(XspressProcessPlugin SHARED XspressProcessPlugin.cpp)
 target_link_libraries(XspressProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 
 # Add library for Xspress list mode process plugin
-add_library(XspressListModeProcessPlugin SHARED XspressListModeProcessPlugin.cpp XspressListModeProcessPluginLib.cpp)
+add_library(XspressListModeProcessPlugin SHARED XspressListModeProcessPlugin.cpp)
 target_link_libraries(XspressListModeProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 
 # Add library for X3X2 list mode process plugin
-add_library(X3X2ListModeProcessPlugin SHARED X3X2ListModeProcessPlugin.cpp X3X2ListModeProcessPluginLib.cpp)
+add_library(X3X2ListModeProcessPlugin SHARED X3X2ListModeProcessPlugin.cpp X3X2ListModeMemoryBlocks.cpp)
 target_link_libraries(X3X2ListModeProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 
 install(TARGETS XspressProcessPlugin

--- a/cpp/data/frameProcessor/src/CMakeLists.txt
+++ b/cpp/data/frameProcessor/src/CMakeLists.txt
@@ -3,15 +3,15 @@ set(CMAKE_INCLUDE_CURRENT_DIR on)
 include_directories(${FRAMEPROCESSOR_DIR}/include ${ODINDATA_INCLUDE_DIRS} ${HDF5_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS})
 
 # Add library for Xspress process plugin
-add_library(XspressProcessPlugin SHARED XspressProcessPlugin.cpp)
+add_library(XspressProcessPlugin SHARED XspressProcessPlugin.cpp XspressProcessPluginLib.cpp)
 target_link_libraries(XspressProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 
 # Add library for Xspress list mode process plugin
-add_library(XspressListModeProcessPlugin SHARED XspressListModeProcessPlugin.cpp)
+add_library(XspressListModeProcessPlugin SHARED XspressListModeProcessPlugin.cpp XspressListModeProcessPluginLib.cpp)
 target_link_libraries(XspressListModeProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 
 # Add library for X3X2 list mode process plugin
-add_library(X3X2ListModeProcessPlugin SHARED X3X2ListModeProcessPlugin.cpp X3X2ListModeMemoryBlocks.cpp)
+add_library(X3X2ListModeProcessPlugin SHARED X3X2ListModeProcessPlugin.cpp X3X2ListModeProcessPluginLib.cpp X3X2ListModeMemoryBlocks.cpp)
 target_link_libraries(X3X2ListModeProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 
 install(TARGETS XspressProcessPlugin

--- a/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
@@ -47,7 +47,7 @@ void X3X2ListModeMemoryBlock::set_size(uint32_t bytes)
 
 void X3X2ListModeMemoryBlock::reallocate()
 {
-  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Reallocating X3X2ListModeMemoryBlock to [" << num_bytes_ << "] bytes");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Reallocating X3X2ListModeMemoryBlock to [" << num_bytes_ << "] bytes");
   if (ptr_){
     free(ptr_);
   }
@@ -68,14 +68,13 @@ void X3X2ListModeMemoryBlock::reset_frame_count()
 
 boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
 {
-  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Getting complete frame " << frame_count_ << " of " << num_bytes_ << " bytes");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Getting complete frame " << frame_count_ << " of " << num_bytes_ << " bytes");
   boost::shared_ptr <Frame> frame;
 
-  // Create the frame around the current (partial) block
+  // Create the frame around the complete block
   dimensions_t dims;
   FrameMetaData list_metadata(frame_count_, name_, data_type_, "", dims);
-  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, num_bytes_));
-  memcpy(frame->get_data_ptr(), ptr_, num_bytes_);
+  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, ptr_, num_bytes_));
 
   // Reset the block
   reset();
@@ -94,8 +93,11 @@ boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::flush()
   // Create the frame around the current (partial) block
   dimensions_t dims;
   FrameMetaData list_metadata(frame_count_, name_, data_type_, "", dims);
-  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, filled_size_));
-  memcpy(frame->get_data_ptr(), ptr_, filled_size_);
+  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, ptr_, filled_size_));
+
+  // We don't reset here as this is called at the end of an acquisition by
+  // flush_close_acquisition. Resetting should reset the memory block before
+  // the next one starts
 
   return frame;
 }

--- a/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
@@ -1,0 +1,112 @@
+#include <iostream>
+
+#include "DataBlockFrame.h"
+#include "DebugLevelLogger.h"
+
+#include "X3X2ListModeMemoryBlocks.h"
+#include "FrameProcessorDefinitions.h"
+
+namespace FrameProcessor {
+
+X3X2ListModeMemoryBlock::X3X2ListModeMemoryBlock(const std::string& name) :
+  ptr_(0),
+  num_bytes_(0),
+  filled_size_(0),
+  frame_count_(0)
+{
+  // Setup logging for the class
+  logger_ = Logger::getLogger("FP.X3X2ListModeProcessPlugin");
+  LOG4CXX_INFO(logger_, "Created X3X2ListModeMemoryBlock");
+
+  name_ = name;
+}
+
+X3X2ListModeMemoryBlock::~X3X2ListModeMemoryBlock()
+{
+  if (ptr_){
+    free(ptr_);
+  }
+}
+
+void X3X2ListModeMemoryBlock::set_size(uint32_t bytes)
+{
+  // Round allocation down to number of whole events
+  num_bytes_ = (bytes/num_bytes_per_event_)*num_bytes_per_event_;
+  reallocate();
+}
+
+void X3X2ListModeMemoryBlock::reallocate()
+{
+  LOG4CXX_INFO(logger_, "Reallocating X3X2ListModeMemoryBlock to [" << num_bytes_ << "] bytes");
+  if (ptr_){
+    free(ptr_);
+  }
+  ptr_ = (char *)malloc(num_bytes_);
+  reset();
+}
+
+void X3X2ListModeMemoryBlock::reset()
+{
+  memset(ptr_, 0, num_bytes_);
+  filled_size_ = 0;
+}
+
+void X3X2ListModeMemoryBlock::reset_frame_count()
+{
+  frame_count_ = 0;
+}
+
+boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::add_event(uint64_t time_stamp)
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Calculate the current end of data pointer location
+  char *dest = (char *)ptr_;
+  dest += filled_size_;
+
+  // Add the event
+  *((uint64_t *)dest) = time_stamp;
+
+  filled_size_ += sizeof(uint64_t);
+
+  // Final check, if we have a full buffer then send it out
+  if (filled_size_ == num_bytes_){
+    frame = this->to_frame();
+  }
+
+  return frame;
+}
+
+boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Create the frame around the current (partial) block
+  dimensions_t dims;
+  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
+  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, num_bytes_));
+  memcpy(frame->get_data_ptr(), ptr_, num_bytes_);
+
+  // Reset the block
+  reset();
+
+  // Add 1 to the frame count
+  frame_count_++;
+
+  return frame;
+}
+
+boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::flush()
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Create the frame around the current (partial) block
+  dimensions_t dims;
+  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
+  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, filled_size_));
+  memcpy(frame->get_data_ptr(), ptr_, filled_size_);
+
+  return frame;
+}
+
+}

--- a/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
@@ -68,7 +68,7 @@ void X3X2ListModeMemoryBlock::reset_frame_count()
 
 boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
 {
-  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Flushing frame " << frame_count_ << " of " << num_bytes_ << " bytes");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Getting complete frame " << frame_count_ << " of " << num_bytes_ << " bytes");
   boost::shared_ptr <Frame> frame;
 
   // Create the frame around the current (partial) block

--- a/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
@@ -174,7 +174,7 @@ boost::shared_ptr <Frame> X3X2ListModeTimestampMemoryBlock::add_timestamp(uint64
 
 
 // ============================================================================
-// Timeframe memory block
+// Event height memory block
 // ============================================================================
 
 X3X2ListModeEventHeightMemoryBlock::X3X2ListModeEventHeightMemoryBlock(const std::string& name) :
@@ -199,6 +199,41 @@ boost::shared_ptr <Frame> X3X2ListModeEventHeightMemoryBlock::add_event_height(u
   *((uint16_t *)dest) = event_height;
 
   filled_size_ += sizeof(uint16_t);
+
+  // Final check, if we have a full buffer then send it out
+  if (filled_size_ == num_bytes_){
+    frame = this->to_frame();
+  }
+
+  return frame;
+}
+
+// ============================================================================
+// Reset flag memory block
+// ============================================================================
+
+X3X2ListModeResetFlagMemoryBlock::X3X2ListModeResetFlagMemoryBlock(const std::string& name) :
+    X3X2ListModeMemoryBlock(name, raw_8bit, 1)
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeResetFlagMemoryBlock");
+}
+
+X3X2ListModeResetFlagMemoryBlock::~X3X2ListModeResetFlagMemoryBlock()
+{
+}
+
+boost::shared_ptr <Frame> X3X2ListModeResetFlagMemoryBlock::add_reset_flag(uint8_t reset_flag)
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Calculate the current end of data pointer location
+  char *dest = (char *)ptr_;
+  dest += filled_size_;
+
+  // Add the event
+  *((uint8_t *)dest) = reset_flag;
+
+  filled_size_ += sizeof(uint8_t);
 
   // Final check, if we have a full buffer then send it out
   if (filled_size_ == num_bytes_){

--- a/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
@@ -38,6 +38,9 @@ X3X2ListModeMemoryBlock::~X3X2ListModeMemoryBlock()
   }
 }
 
+/**
+ * Set the size of the memory block in bytes.
+ */
 void X3X2ListModeMemoryBlock::set_size(uint32_t bytes)
 {
   // Round allocation down to number of whole events

--- a/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
@@ -87,7 +87,7 @@ boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
 
 boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::flush()
 {
-  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Flushing partial frame " << frame_count_ << " of " << filled_size_ << " bytes");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Flushing partial frame " << frame_count_ << " of " << filled_size_ << " bytes");
   boost::shared_ptr <Frame> frame;
 
   // Create the frame around the current (partial) block

--- a/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
@@ -8,18 +8,27 @@
 
 namespace FrameProcessor {
 
-X3X2ListModeMemoryBlock::X3X2ListModeMemoryBlock(const std::string& name, uint32_t num_bytes_per_event) :
+// ============================================================================
+// Base memory block class
+// ============================================================================
+
+X3X2ListModeMemoryBlock::X3X2ListModeMemoryBlock(
+    const std::string& name,
+    DataType data_type,
+    uint32_t num_bytes_per_event
+  ) :
   ptr_(0),
   num_bytes_(0),
   filled_size_(0),
   frame_count_(0),
+  data_type_(data_type),
   num_bytes_per_event_(num_bytes_per_event)
 {
+  name_ = name;
+
   // Setup logging for the class
   logger_ = Logger::getLogger("FP.X3X2ListModeProcessPlugin");
-  LOG4CXX_INFO(logger_, "Created X3X2ListModeMemoryBlock");
-
-  name_ = name;
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeMemoryBlock");
 }
 
 X3X2ListModeMemoryBlock::~X3X2ListModeMemoryBlock()
@@ -38,7 +47,7 @@ void X3X2ListModeMemoryBlock::set_size(uint32_t bytes)
 
 void X3X2ListModeMemoryBlock::reallocate()
 {
-  LOG4CXX_INFO(logger_, "Reallocating X3X2ListModeMemoryBlock to [" << num_bytes_ << "] bytes");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Reallocating X3X2ListModeMemoryBlock to [" << num_bytes_ << "] bytes");
   if (ptr_){
     free(ptr_);
   }
@@ -59,11 +68,12 @@ void X3X2ListModeMemoryBlock::reset_frame_count()
 
 boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
 {
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Flushing frame " << frame_count_ << " of " << num_bytes_ << " bytes");
   boost::shared_ptr <Frame> frame;
 
   // Create the frame around the current (partial) block
   dimensions_t dims;
-  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
+  FrameMetaData list_metadata(frame_count_, name_, data_type_, "", dims);
   frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, num_bytes_));
   memcpy(frame->get_data_ptr(), ptr_, num_bytes_);
 
@@ -78,21 +88,63 @@ boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
 
 boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::flush()
 {
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Flushing partial frame " << frame_count_ << " of " << filled_size_ << " bytes");
   boost::shared_ptr <Frame> frame;
 
   // Create the frame around the current (partial) block
   dimensions_t dims;
-  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
+  FrameMetaData list_metadata(frame_count_, name_, data_type_, "", dims);
   frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, filled_size_));
   memcpy(frame->get_data_ptr(), ptr_, filled_size_);
 
   return frame;
 }
 
-X3X2ListModeTimestampMemoryBlock::X3X2ListModeTimestampMemoryBlock(const std::string& name) :
-    X3X2ListModeMemoryBlock(name, 8)
+
+// ============================================================================
+// Timeframe memory block
+// ============================================================================
+
+X3X2ListModeTimeframeMemoryBlock::X3X2ListModeTimeframeMemoryBlock(const std::string& name) :
+    X3X2ListModeMemoryBlock(name, raw_64bit, 8)
 {
-  LOG4CXX_INFO(logger_, "Created X3X2ListModeTimestampMemoryBlock");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeTimeframeMemoryBlock");
+}
+
+X3X2ListModeTimeframeMemoryBlock::~X3X2ListModeTimeframeMemoryBlock()
+{
+}
+
+boost::shared_ptr <Frame> X3X2ListModeTimeframeMemoryBlock::add_timeframe(uint64_t timeframe)
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Calculate the current end of data pointer location
+  char *dest = (char *)ptr_;
+  dest += filled_size_;
+
+  // Add the event
+  *((uint64_t *)dest) = timeframe;
+
+  filled_size_ += sizeof(uint64_t);
+
+  // Final check, if we have a full buffer then send it out
+  if (filled_size_ == num_bytes_){
+    frame = this->to_frame();
+  }
+
+  return frame;
+}
+
+
+// ============================================================================
+// Timestamp memory block
+// ============================================================================
+
+X3X2ListModeTimestampMemoryBlock::X3X2ListModeTimestampMemoryBlock(const std::string& name) :
+    X3X2ListModeMemoryBlock(name, raw_64bit, 8)
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeTimestampMemoryBlock");
 }
 
 X3X2ListModeTimestampMemoryBlock::~X3X2ListModeTimestampMemoryBlock()
@@ -111,6 +163,42 @@ boost::shared_ptr <Frame> X3X2ListModeTimestampMemoryBlock::add_timestamp(uint64
   *((uint64_t *)dest) = timestamp;
 
   filled_size_ += sizeof(uint64_t);
+
+  // Final check, if we have a full buffer then send it out
+  if (filled_size_ == num_bytes_){
+    frame = this->to_frame();
+  }
+
+  return frame;
+}
+
+
+// ============================================================================
+// Timeframe memory block
+// ============================================================================
+
+X3X2ListModeEventHeightMemoryBlock::X3X2ListModeEventHeightMemoryBlock(const std::string& name) :
+    X3X2ListModeMemoryBlock(name, raw_16bit, 2)
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeEventHeightMemoryBlock");
+}
+
+X3X2ListModeEventHeightMemoryBlock::~X3X2ListModeEventHeightMemoryBlock()
+{
+}
+
+boost::shared_ptr <Frame> X3X2ListModeEventHeightMemoryBlock::add_event_height(uint16_t event_height)
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Calculate the current end of data pointer location
+  char *dest = (char *)ptr_;
+  dest += filled_size_;
+
+  // Add the event
+  *((uint16_t *)dest) = event_height;
+
+  filled_size_ += sizeof(uint16_t);
 
   // Final check, if we have a full buffer then send it out
   if (filled_size_ == num_bytes_){

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -62,7 +62,7 @@ void X3X2ListModeMemoryBlock::reset_frame_count()
   frame_count_ = 0;
 }
 
-boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::add_event(uint64_t time_frame, uint64_t time_stamp, uint64_t event_height)
+boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::add_event(uint64_t time_stamp)
 {
   boost::shared_ptr <Frame> frame;
 
@@ -71,12 +71,9 @@ boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::add_event(uint64_t time_frame
   dest += filled_size_;
 
   // Add the event
-  // *(reinterpret_cast<uint64_t>(dest)) = event_height;
-  *((uint64_t *)dest) = time_frame;
-  *((uint64_t *)(dest) + 1) = time_stamp;
-  *((uint64_t *)(dest) + 2) = event_height;
+  *((uint64_t *)dest) = time_stamp;
 
-  filled_size_ += 3*sizeof(uint64_t);
+  filled_size_ += sizeof(uint64_t);
 
   // Final check, if we have a full buffer then send it out
   if (filled_size_ == num_bytes_){
@@ -257,7 +254,7 @@ void X3X2ListModeProcessPlugin::setup_memory_allocation()
   std::vector<uint32_t>::iterator iter;
   for (iter = channels_.begin(); iter != channels_.end(); ++iter){
     std::stringstream ss;
-    ss << "raw_" << *iter;
+    ss << "ch" << *iter << "_time_stamp";
     boost::shared_ptr<X3X2ListModeMemoryBlock> ptr = boost::shared_ptr<X3X2ListModeMemoryBlock>(new X3X2ListModeMemoryBlock(ss.str()));
     ptr->set_size(frame_size_bytes_);
     memory_ptrs_[*iter] = ptr;
@@ -401,7 +398,7 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         //return
 
         // Add event
-        boost::shared_ptr <Frame> list_frame = (memory_ptrs_[channel])->add_event(time_frame, time_stamp, event_height);
+        boost::shared_ptr <Frame> list_frame = (memory_ptrs_[channel])->add_event(time_stamp);
         if (list_frame){
           // LOG4CXX_DEBUG_LEVEL(1, logger_, "Completed frame for channel " << channel << ", pushing");
           // There is a full frame available for pushing

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -292,6 +292,9 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
 {
   // LOG4CXX_INFO(logger_, "Processing frame " << frame->get_frame_number() << " of size " << frame->get_data_size() << " at " << frame->get_data_ptr());
 
+  // Packet arrived after we got the EOF for the desired time frame
+  if (acquisition_complete_) return;
+
   uint16_t* frame_data = static_cast<uint16_t *>(frame->get_data_ptr());
 
   // TODO: remove after testing
@@ -433,6 +436,7 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
               acquisition_complete_ = true;
               LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames completed for all channels");
               LOG4CXX_INFO(logger_, "Total events across all channels: " << num_events_);
+              return;
             }
           }
         }

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -1,9 +1,11 @@
 #include <iostream>
+
 #include "DataBlockFrame.h"
+#include "DebugLevelLogger.h"
+
 #include "X3X2ListModeProcessPlugin.h"
 #include "FrameProcessorDefinitions.h"
 #include "X3X2Definitions.h"
-#include "DebugLevelLogger.h"
 
 
 namespace FrameProcessor {
@@ -13,107 +15,6 @@ const std::string X3X2ListModeProcessPlugin::CONFIG_RESET_ACQUISITION =  "reset"
 const std::string X3X2ListModeProcessPlugin::CONFIG_FLUSH_ACQUISITION =  "flush";
 const std::string X3X2ListModeProcessPlugin::CONFIG_FRAME_SIZE =         "frame_size";
 const std::string X3X2ListModeProcessPlugin::CONFIG_TIME_FRAMES =        "time_frames";
-
-X3X2ListModeMemoryBlock::X3X2ListModeMemoryBlock(const std::string& name) :
-  ptr_(0),
-  num_bytes_(0),
-  filled_size_(0),
-  frame_count_(0)
-{
-  // Setup logging for the class
-  logger_ = Logger::getLogger("FP.X3X2ListModeProcessPlugin");
-  LOG4CXX_INFO(logger_, "Created X3X2ListModeMemoryBlock");
-
-  name_ = name;
-}
-
-X3X2ListModeMemoryBlock::~X3X2ListModeMemoryBlock()
-{
-  if (ptr_){
-    free(ptr_);
-  }
-}
-
-void X3X2ListModeMemoryBlock::set_size(uint32_t bytes)
-{
-  // Round allocation down to number of whole events
-  num_bytes_ = (bytes/num_bytes_per_event_)*num_bytes_per_event_;
-  reallocate();
-}
-
-void X3X2ListModeMemoryBlock::reallocate()
-{
-  LOG4CXX_INFO(logger_, "Reallocating X3X2ListModeMemoryBlock to [" << num_bytes_ << "] bytes");
-  if (ptr_){
-    free(ptr_);
-  }
-  ptr_ = (char *)malloc(num_bytes_);
-  reset();
-}
-
-void X3X2ListModeMemoryBlock::reset()
-{
-  memset(ptr_, 0, num_bytes_);
-  filled_size_ = 0;
-}
-
-void X3X2ListModeMemoryBlock::reset_frame_count()
-{
-  frame_count_ = 0;
-}
-
-boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::add_event(uint64_t time_stamp)
-{
-  boost::shared_ptr <Frame> frame;
-
-  // Calculate the current end of data pointer location
-  char *dest = (char *)ptr_;
-  dest += filled_size_;
-
-  // Add the event
-  *((uint64_t *)dest) = time_stamp;
-
-  filled_size_ += sizeof(uint64_t);
-
-  // Final check, if we have a full buffer then send it out
-  if (filled_size_ == num_bytes_){
-    frame = this->to_frame();
-  }
-
-  return frame;
-}
-
-boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
-{
-  boost::shared_ptr <Frame> frame;
-
-  // Create the frame around the current (partial) block
-  dimensions_t dims;
-  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
-  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, num_bytes_));
-  memcpy(frame->get_data_ptr(), ptr_, num_bytes_);
-
-  // Reset the block
-  reset();
-
-  // Add 1 to the frame count
-  frame_count_++;
-
-  return frame;
-}
-
-boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::flush()
-{
-  boost::shared_ptr <Frame> frame;
-
-  // Create the frame around the current (partial) block
-  dimensions_t dims;
-  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
-  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, filled_size_));
-  memcpy(frame->get_data_ptr(), ptr_, filled_size_);
-
-  return frame;
-}
 
 X3X2ListModeProcessPlugin::X3X2ListModeProcessPlugin() :
   num_channels_(0),

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -340,6 +340,8 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
 
   uint16_t* frame_data = static_cast<uint16_t *>(frame->get_data_ptr());
 
+  boost::shared_ptr <Frame> list_frame;
+
   // TODO: remove after testing
   std::string ids("");
   std::string values("");
@@ -443,7 +445,7 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         if (!end_of_frame)
         {
           if (dummy_event == 0) {
-            boost::shared_ptr <Frame> list_frame = (timeframe_memory_ptrs_[channel])->add_timeframe(time_frame);
+            list_frame = (timeframe_memory_ptrs_[channel])->add_timeframe(time_frame);
             // Memory block frame completed
             if (list_frame) this->push(list_frame);
 

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -443,22 +443,24 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         if (!end_of_frame)
         {
           if (dummy_event == 0) {
-            boost::shared_ptr <Frame> tf_frame = (timeframe_memory_ptrs_[channel])->add_timeframe(time_frame);
-            // Memory block frame completed
-            if (tf_frame) this->push(tf_frame);
+            boost::shared_ptr <Frame> frame;
 
-            boost::shared_ptr <Frame> ts_frame = (timestamp_memory_ptrs_[channel])->add_timestamp(time_stamp);
+            frame = (timeframe_memory_ptrs_[channel])->add_timeframe(time_frame);
             // Memory block frame completed
-            if (ts_frame) this->push(ts_frame);
+            if (frame) this->push(frame);
 
-            boost::shared_ptr <Frame> eh_frame = (event_height_memory_ptrs_[channel])->add_event_height(event_height);
+            frame = (timestamp_memory_ptrs_[channel])->add_timestamp(time_stamp);
             // Memory block frame completed
-            if (eh_frame) this->push(eh_frame);
+            if (frame) this->push(frame);
+
+            frame = (event_height_memory_ptrs_[channel])->add_event_height(event_height);
+            // Memory block frame completed
+            if (frame) this->push(frame);
 
             reset_flag = (id == 14) ? true : false;
-            boost::shared_ptr <Frame> rf_frame = (reset_flag_memory_ptrs_[channel])->add_reset_flag(reset_flag);
+            frame = (reset_flag_memory_ptrs_[channel])->add_reset_flag(reset_flag);
             // Memory block frame completed
-            if (rf_frame) this->push(rf_frame);
+            if (frame) this->push(frame);
 
             // Track overall number of recorded events in acquisition (including resets)
             num_events_[channel]++;

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -407,7 +407,7 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         ttl_a = value & 0x2;
         ttl_b = value & 0x4;
         dummy_event = value & 0x8;
-        time_frame = (time_frame & 0xFFFFFFFFFFFFFF00) | ((value_64 &0xFF0) >> 4);
+        time_frame = (time_frame & 0xFFFFFFFFFFFFFF00) | ((value_64 & 0xFF0) >> 4);
         break;
       case 5:
         time_frame = (time_frame & 0xFFFFFFFFFFF000FF) | (value_64 << 8);
@@ -424,8 +424,8 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
       case 9:
         // Calculate actual channel in system
         channel = (value >> 8) + channel_offset_;
-        // Check we have the right channel (and ignore markers)
-        if (timestamp_memory_ptrs_.find(channel) == timestamp_memory_ptrs_.end()) {
+        // Check we have the right channel (and ignore marker channels for now)
+        if (std::find(channels_.begin(), channels_.end(), channel) == channels_.end()) {
           // Ignore entire packet
           return;
         }

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -172,7 +172,7 @@ void X3X2ListModeProcessPlugin::flush_timeframe_memory_blocks()
   std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock> >::iterator iter;
   for (iter = timeframe_memory_ptrs_.begin(); iter != timeframe_memory_ptrs_.end(); ++iter){
     LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing timeframe for channel " << iter->first);
-    boost::shared_ptr <Frame> list_frame = iter->second->flush();
+    boost::shared_ptr <Frame> list_frame = iter->second->to_frame();
     if (list_frame){
       this->push(list_frame);
     }
@@ -184,7 +184,7 @@ void X3X2ListModeProcessPlugin::flush_timestamp_memory_blocks()
   std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimestampMemoryBlock> >::iterator iter;
   for (iter = timestamp_memory_ptrs_.begin(); iter != timestamp_memory_ptrs_.end(); ++iter){
     LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing timestamp for channel " << iter->first);
-    boost::shared_ptr <Frame> list_frame = iter->second->flush();
+    boost::shared_ptr <Frame> list_frame = iter->second->to_frame();
     if (list_frame){
       this->push(list_frame);
     }
@@ -196,7 +196,7 @@ void X3X2ListModeProcessPlugin::flush_event_height_memory_blocks()
   std::map<uint32_t, boost::shared_ptr<X3X2ListModeEventHeightMemoryBlock> >::iterator iter;
   for (iter = event_height_memory_ptrs_.begin(); iter != event_height_memory_ptrs_.end(); ++iter){
     LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing event height for channel " << iter->first);
-    boost::shared_ptr <Frame> list_frame = iter->second->flush();
+    boost::shared_ptr <Frame> list_frame = iter->second->to_frame();
     if (list_frame){
       this->push(list_frame);
     }
@@ -208,7 +208,7 @@ void X3X2ListModeProcessPlugin::flush_reset_flag_memory_blocks()
   std::map<uint32_t, boost::shared_ptr<X3X2ListModeResetFlagMemoryBlock> >::iterator iter;
   for (iter = reset_flag_memory_ptrs_.begin(); iter != reset_flag_memory_ptrs_.end(); ++iter){
     LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing event height for channel " << iter->first);
-    boost::shared_ptr <Frame> list_frame = iter->second->flush();
+    boost::shared_ptr <Frame> list_frame = iter->second->to_frame();
     if (list_frame){
       this->push(list_frame);
     }
@@ -340,8 +340,6 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
 
   uint16_t* frame_data = static_cast<uint16_t *>(frame->get_data_ptr());
 
-  boost::shared_ptr <Frame> list_frame;
-
   // TODO: remove after testing
   std::string ids("");
   std::string values("");
@@ -445,22 +443,22 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         if (!end_of_frame)
         {
           if (dummy_event == 0) {
-            list_frame = (timeframe_memory_ptrs_[channel])->add_timeframe(time_frame);
+            boost::shared_ptr <Frame> tf_frame = (timeframe_memory_ptrs_[channel])->add_timeframe(time_frame);
             // Memory block frame completed
-            if (list_frame) this->push(list_frame);
+            if (tf_frame) this->push(tf_frame);
 
-            list_frame = (timestamp_memory_ptrs_[channel])->add_timestamp(time_stamp);
+            boost::shared_ptr <Frame> ts_frame = (timestamp_memory_ptrs_[channel])->add_timestamp(time_stamp);
             // Memory block frame completed
-            if (list_frame) this->push(list_frame);
+            if (ts_frame) this->push(ts_frame);
 
-            list_frame = (event_height_memory_ptrs_[channel])->add_event_height(event_height);
+            boost::shared_ptr <Frame> eh_frame = (event_height_memory_ptrs_[channel])->add_event_height(event_height);
             // Memory block frame completed
-            if (list_frame) this->push(list_frame);
+            if (eh_frame) this->push(eh_frame);
 
             reset_flag = (id == 14) ? true : false;
-            list_frame = (reset_flag_memory_ptrs_[channel])->add_reset_flag(reset_flag);
+            boost::shared_ptr <Frame> rf_frame = (reset_flag_memory_ptrs_[channel])->add_reset_flag(reset_flag);
             // Memory block frame completed
-            if (list_frame) this->push(list_frame);
+            if (rf_frame) this->push(rf_frame);
 
             // Track overall number of recorded events in acquisition (including resets)
             num_events_[channel]++;

--- a/python/src/xspress_detector/control/adapter.py
+++ b/python/src/xspress_detector/control/adapter.py
@@ -90,7 +90,7 @@ class XspressAdapter(AsyncApiAdapter):
             if not isinstance(response, dict):
                 response = {"value": response}
 
-            respose = "{}".format(response)
+            response = "{}".format(response)
             status_code = 200
         except LookupError as e:
             response = {'invalid path': str(e)}


### PR DESCRIPTION
These are changes for the X3X2 list mode process plugin to save list mode data as separate datasets per event field, versus using a single dataset.