### PR TITLE
Fix/receiver buffer size

### DIFF
--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -4,6 +4,23 @@ Change log
 Changes made by Quantum Detectors to this repository are recorded below.
 
 
+Unreleased
+----------
+
+Changed:
+
+- Increased the size of the X3X2ListModeFrameDecoder buffer to 12,800 TCP frames
+  (100MB) per channel as the default value of 5 meant that old buffer data was
+  being overwritten before it was being processed when the Xspress system was
+  generating a large number of events
+- Added logging to check the time frames and time stamps do not decrease
+  during an acquisition. This could happen if the processors fall behind the
+  receivers and the receivers end up overwriting data that hasn't been
+  processed in the circular buffer. This will be fixed in the future by changing
+  the TCP receiver to drop packets that would otherwise overwrite the unprocessed
+  data.
+
+
 0.5.0+qd0.4
 -----------
 

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -10,7 +10,7 @@ Unreleased
 Changed:
 
 - Increased the size of the X3X2ListModeFrameDecoder buffer to 12,800 TCP frames
-  (100MB) per channel as the default value of 5 meant that old buffer data was
+  (100MB) per receiver as the default value of 5 meant that old buffer data was
   being overwritten before it was being processed when the Xspress system was
   generating a large number of events
 - Added logging to check the time frames and time stamps do not decrease

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -77,7 +77,7 @@ namespace FrameProcessor
     // Tracking per channel
     std::map<uint32_t, bool> completed_channels_;
     std::map<uint32_t, uint64_t> num_events_;
-    std::map<uint32_t, uint64_t> current_time_frames_;
+    std::map<uint32_t, uint64_t> prev_time_frames_;
     std::map<uint32_t, uint64_t> prev_time_stamps_;
 
     // Memory blocks for event fields

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -77,6 +77,8 @@ namespace FrameProcessor
     // Tracking per channel
     std::map<uint32_t, bool> completed_channels_;
     std::map<uint32_t, uint64_t> num_events_;
+    std::map<uint32_t, uint64_t> current_time_frames_;
+    std::map<uint32_t, uint64_t> prev_time_stamps_;
 
     // Memory blocks for event fields
     std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock> > timeframe_memory_ptrs_;

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -364,10 +364,6 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
 
   uint16_t* frame_data = static_cast<uint16_t *>(frame->get_data_ptr());
 
-  // TODO: remove after testing
-  std::string ids("");
-  std::string values("");
-
   // Event attributes
   uint16_t acquisition_number = 0;
   uint64_t time_frame = 0;
@@ -398,10 +394,6 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
     id = frame_data[field] >> 12;
     value = frame_data[field] & 0xFFF;
     value_64 = (uint64_t) value;
-
-    // TODO: remove after testing
-    //ids += std::to_string(id) + ",";
-    //values += std::to_string(value) + ",";
 
     switch (id)
     {

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -465,18 +465,43 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         {
           if (time_frame < current_time_frames_[channel])
           {
-            LOG4CXX_INFO(logger_, "Channel " << channel << " stepped back from " << current_time_frames_[channel] << " to " << time_frame);
+            LOG4CXX_INFO(
+              logger_,
+              "Channel "
+              << channel
+              << " stepped back from "
+              << current_time_frames_[channel]
+              << " to "
+              << time_frame
+              << " at field " << field
+            );
           }
           else if (time_frame != current_time_frames_[channel] + 1)
           {
-            LOG4CXX_INFO(logger_, "Channel " << channel << " jumped from " << current_time_frames_[channel] << " to " << time_frame);
+            LOG4CXX_INFO(
+              logger_,
+              "Channel "
+              << channel
+              << " jumped from "
+              << current_time_frames_[channel]
+              << " to "
+              << time_frame
+              << " (eof: " << end_of_frame << ")"
+            );
           }
           current_time_frames_[channel] = time_frame;
         }
 
         if (time_stamp < prev_time_stamps_[channel])
         {
-          LOG4CXX_INFO(logger_, "Channel " << channel << " walk back timestamp at field " << field);
+          LOG4CXX_INFO(
+            logger_,
+            "Channel "
+            << channel
+            << " walk back timestamp at field "
+            << field
+            << " (eof: " << end_of_frame << ")"
+          );
         }
         prev_time_stamps_[channel] = time_stamp;
 

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -22,7 +22,7 @@ X3X2ListModeProcessPlugin::X3X2ListModeProcessPlugin() :
   num_time_frames_(0),
   num_events_(),
   completed_channels_(),
-  current_time_frames_(),
+  prev_time_frames_(),
   prev_time_stamps_(),
   acquisition_complete_(false)
 {
@@ -309,14 +309,14 @@ void X3X2ListModeProcessPlugin::setup_channel_memory_blocks(uint32_t channel)
 void X3X2ListModeProcessPlugin::reset_channel_statistics()
 {
   completed_channels_.clear();
-  current_time_frames_.clear();
+  prev_time_frames_.clear();
   prev_time_stamps_.clear();
   num_events_.clear();
   for (auto const& chan : channels_)
   {
     completed_channels_[chan] = false;
     num_events_[chan] = 0;
-    current_time_frames_[chan] = 0;
+    prev_time_frames_[chan] = 0;
     prev_time_stamps_[chan] = 0;
   }
 }
@@ -459,50 +459,37 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         // Event height
         event_height = value;
 
-        // TODO: remove when tested?
-        // Keep track of previous time frame
-        if (time_frame != current_time_frames_[channel])
+        // Check for time frame and time stamp decreasing
+        // this may be a sign that the receiver buffer
+        // is being overwritten before being processed
+        if (time_frame < prev_time_frames_[channel])
         {
-          if (time_frame < current_time_frames_[channel])
-          {
-            LOG4CXX_INFO(
-              logger_,
-              "Channel "
-              << channel
-              << " stepped back from "
-              << current_time_frames_[channel]
-              << " to "
-              << time_frame
-              << " at field " << field
-            );
-          }
-          else if (time_frame != current_time_frames_[channel] + 1)
-          {
-            LOG4CXX_INFO(
-              logger_,
-              "Channel "
-              << channel
-              << " jumped from "
-              << current_time_frames_[channel]
-              << " to "
-              << time_frame
-              << " (eof: " << end_of_frame << ")"
-            );
-          }
-          current_time_frames_[channel] = time_frame;
+          LOG4CXX_INFO(
+            logger_,
+            "Channel "
+            << channel
+            << " stepped back from "
+            << prev_time_frames_[channel]
+            << " to "
+            << time_frame
+            << " at field " << field
+          );
         }
-
         if (time_stamp < prev_time_stamps_[channel])
         {
           LOG4CXX_INFO(
             logger_,
             "Channel "
             << channel
-            << " walk back timestamp at field "
+            << " walked back timestamp at field "
             << field
-            << " (eof: " << end_of_frame << ")"
+            << " from "
+            << prev_time_stamps_[channel]
+            << " to "
+            << time_stamp
           );
         }
+        prev_time_frames_[channel] = time_frame;
         prev_time_stamps_[channel] = time_stamp;
 
         // xspress3m_active_readout only counts events when not end of frame so we copy this logic here
@@ -536,7 +523,6 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         {
           // TODO: work out why we get more events after the end of frame marker is set and see if we need to
           // save them or ignore them (we ignore them here)
-          // LOG4CXX_INFO(logger_, "Channel " << channel << " got end of frame for frame " << time_frame);
           if (time_frame + 1 == num_time_frames_)
           {
             LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames complete for channel " << channel);

--- a/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
+++ b/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
@@ -23,7 +23,7 @@ namespace X3X2ListModeFrameDecoderDefaults {
   const int buffer_id = 0;
   const size_t max_size = X3X2_MINI_TCP_FRAME_SIZE; // Each TCP frame is 8192 bytes of 4096 16 bit words
   const size_t header_size = 0; // Initially we do not need a header
-  const int num_buffers = 5;
+  const int num_buffers = 12800; // 100MB buffer
 } // namespace X3X2ListModeFrameDecoderDefaults
 
 class X3X2ListModeFrameDecoder : public FrameDecoderTCP {

--- a/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
+++ b/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
@@ -84,9 +84,11 @@ void *X3X2ListModeFrameDecoder::get_next_message_buffer(void) {
   if (receive_state_ != FrameDecoder::FrameReceiveStateIncomplete) {
     // get id in buffer circularly
     if (current_frame_buffer_id_ + 1 >= num_buffers_)
+    {
+      LOG4CXX_INFO(logger_, "Reached end of buffer. Starting over");
       current_frame_buffer_id_ = 0;
-    else
-      current_frame_buffer_id_++;
+    }
+    else current_frame_buffer_id_++;
 
     // Update position to new frame in frame buffer
     current_raw_buffer_ = buffer_manager_->get_buffer_address(current_frame_buffer_id_);

--- a/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
+++ b/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
@@ -82,12 +82,8 @@ void X3X2ListModeFrameDecoder::request_configuration(
 void *X3X2ListModeFrameDecoder::get_next_message_buffer(void) {
   // only increment buffer when frame is complete
   if (receive_state_ != FrameDecoder::FrameReceiveStateIncomplete) {
-    // get id in buffer circularly
-    if (current_frame_buffer_id_ + 1 >= num_buffers_)
-    {
-      LOG4CXX_INFO(logger_, "Reached end of buffer. Starting over");
-      current_frame_buffer_id_ = 0;
-    }
+    // Get the buffer ID from the circular buffer
+    if (current_frame_buffer_id_ + 1 >= num_buffers_) current_frame_buffer_id_ = 0;
     else current_frame_buffer_id_++;
 
     // Update position to new frame in frame buffer
@@ -132,9 +128,8 @@ X3X2ListModeFrameDecoder::process_message(size_t bytes_received) {
   // LOG4CXX_INFO(logger_, "Processing " << bytes_received << " bytes");
   if (read_so_far_ + bytes_received == frame_size_) {
     read_so_far_ = 0;
-    // For now just send a single TCP frame
-    // LOG4CXX_INFO(logger_, "Completed TCP frame: " << current_frame_number_ << " in buffer " << current_frame_buffer_id_);
 
+    // Just send a single TCP frame
     ready_callback_(current_frame_buffer_id_, current_frame_number_);
 
     // Increment frame number
@@ -158,8 +153,8 @@ X3X2ListModeFrameDecoder::process_message(size_t bytes_received) {
 /**
  * Get the size of the next message to receiver over the TCP socket
  *
- * X3X2 uses fixed 8192 byte TCP frames and pads as necessary so wait
- * for this.
+ * X3X2 uses fixed 8192 byte TCP frames and pads as necessary for
+ * sparse events
  *
  * \return The size of the next TCP message
  */


### PR DESCRIPTION
This increases the TCP buffer size to 100MB per receiver (12,800 TCP frames) from 5 TCP frames, which gives the processors some headroom in case they start falling behind in an acquisition.

Also log when the time stamp or time frame go backwards - which is an indication that the buffer has been overrun and data has been overwritten before it got processed.