### PR TITLE
Feature/playback channel control registers

### DIFF
--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -186,6 +186,7 @@ public:
   virtual int set_trigger_input(bool list_mode) = 0;
   virtual int setup_clocks(int num_cards) = 0;
   virtual int enable_list_mode_resets() = 0;
+  virtual int set_channel_sources(int run_flags) = 0;
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -157,6 +157,7 @@ public:
   int set_trigger_input(bool list_mode);
   int setup_clocks(int num_cards);
   int enable_list_mode_resets();
+  int set_channel_sources(int run_flags);
 
 private:
   /** String representation of trigger modes */

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -193,6 +193,7 @@ public:
   int set_trigger_input(bool list_mode);
   int setup_clocks(int num_cards);
   int enable_list_mode_resets();
+  int set_channel_sources(int run_flags);
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -969,4 +969,10 @@ int LibXspressSimulator::enable_list_mode_resets()
   return XSP_STATUS_OK;
 }
 
+int LibXspressSimulator::set_channel_sources(int run_flags)
+{
+  // This is a no op for the simulator
+  return XSP_STATUS_OK;
+}
+
 } /* namespace Xspress */

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -374,6 +374,14 @@ int XspressDetector::restoreSettings()
     }
   }
 
+  // Setup channel data sources
+  if (status == XSP_STATUS_OK){
+    status = detector_->set_channel_sources(xsp_run_flags_);
+    if (status != XSP_STATUS_OK){
+      setErrorString(detector_->getErrorString());
+    }
+  }
+
   // Read existing SCA params
   if (status == XSP_STATUS_OK){
     status = readSCAParams();

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -219,14 +219,22 @@ void X3X2ListModeProcessPlugin::flush_reset_flag_memory_blocks()
 
 void X3X2ListModeProcessPlugin::flush_close_acquisition()
 {
-  LOG4CXX_INFO(logger_, "Flushing and closing acquisition");
+  // Only flush if we have a running acquisition
+  if (!acquisition_complete_)
+  {
+    LOG4CXX_INFO(logger_, "Flushing and closing acquisition");
 
-  flush_timeframe_memory_blocks();
-  flush_timestamp_memory_blocks();
-  flush_event_height_memory_blocks();
-  flush_reset_flag_memory_blocks();
+    flush_timeframe_memory_blocks();
+    flush_timestamp_memory_blocks();
+    flush_event_height_memory_blocks();
+    flush_reset_flag_memory_blocks();
 
-  this->notify_end_of_acquisition();
+    this->notify_end_of_acquisition();
+  }
+  else
+  {
+    LOG4CXX_INFO(logger_, "Skipping flush - no acquisition active");
+  }
 }
 
 /**

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -229,6 +229,9 @@ void X3X2ListModeProcessPlugin::flush_close_acquisition()
     flush_event_height_memory_blocks();
     flush_reset_flag_memory_blocks();
 
+    // Mark acquisition as complete so we do not process any more data
+    acquisition_complete_ = true;
+
     this->notify_end_of_acquisition();
   }
   else
@@ -367,7 +370,9 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
 {
   // LOG4CXX_INFO(logger_, "Processing frame " << frame->get_frame_number() << " of size " << frame->get_data_size() << " at " << frame->get_data_ptr());
 
-  // Packet arrived after we got the EOF for the desired time frame
+  // Packet arrived after we have completed the acquisition - either by
+  // receiving the EOF for the desired TF on all channels or it was manually
+  // stopped using the Odin Data API
   if (acquisition_complete_) return;
 
   uint16_t* frame_data = static_cast<uint16_t *>(frame->get_data_ptr());
@@ -537,7 +542,6 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
             if (completed_channels == num_channels_)
             {
               this->flush_close_acquisition();
-              acquisition_complete_ = true;
               LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames completed for all channels");
               for (auto const& chan : channels_)
               {


### PR DESCRIPTION
- The channel registers are now configured to the correct data source based on what the run flags are set to (i.e. playback data for playback or ADC for real data)
- The flush close acquisition logic is now only called once to prevent the final frame from being pushed twice.