### PR TITLE
Feature/marker channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cmake-build-debug/
 CMakeFiles
 Makefile
 venv
+.vscode/

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -4,6 +4,23 @@ Change log
 Changes made by Quantum Detectors to this repository are recorded below.
 
 
+Unreleased
+----------
+
+Changed:
+
+- Increased the size of the X3X2ListModeFrameDecoder buffer to 12,800 TCP frames
+  (100MB) per receiver as the default value of 5 meant that old buffer data was
+  being overwritten before it was being processed when the Xspress system was
+  generating a large number of events
+- Added logging to check the time frames and time stamps do not decrease
+  during an acquisition. This could happen if the processors fall behind the
+  receivers and the receivers end up overwriting data that hasn't been
+  processed in the circular buffer. This will be fixed in the future by changing
+  the TCP receiver to drop packets that would otherwise overwrite the unprocessed
+  data.
+
+
 0.5.0+qd0.4
 -----------
 

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -4,8 +4,8 @@ Change log
 Changes made by Quantum Detectors to this repository are recorded below.
 
 
-Unreleased
-----------
+0.5.0+qd0.5
+-----------
 
 Changed:
 
@@ -19,6 +19,14 @@ Changed:
   processed in the circular buffer. This will be fixed in the future by changing
   the TCP receiver to drop packets that would otherwise overwrite the unprocessed
   data.
+- Now sets the data sources in the Xspress channel control registers to ADC or
+  playback based on the run flags setting to use the matching data source
+
+Fixed:
+
+- Now only send the last frame on flush_close_acquisition in list mode once -
+  either from acquiring the desired number of time frames or from manually
+  stopping the Odin data writers
 
 
 0.5.0+qd0.4

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,6 +3,17 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
+
+0.5.0+qd0.3
+-----------
+
+Changed:
+
+- Changed the number of processes used in list mode and MCA mode to be the same
+  for support with X3X2 systems.
+- Some tidy up of unused imports
+
+
 0.5.0+qd0.2
 -----------
 

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -1,0 +1,29 @@
+Change log
+==========
+
+Changes made by Quantum Detectors to this repository are recorded below.
+
+0.5.0qd0-1
+----------
+
+Added:
+
+- WIP of X3X2 list mode decoder plugin
+
+Changed:
+
+- C++ control server
+  - now configures X3X2 clocks
+  - now enables resets in list mode
+  - Xspress library configure call explicitly requests list readout mode
+- Python control server
+  - requests X3X2 list mode decoder plugin on configure to list mode
+  - changed number of channels used in list mode
+  - changed frame receiver IP/port configuration (currently listens to
+    scalars socket to leave event TCP/IP socket free for Python)
+
+Fixed:
+
+- Now use Xspress library method `xsp3_histogram_read4d` when reading X3X2 MCA
+  data
+- Set num_cards when detector is configured in control server

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,6 +3,13 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
+0.5.0+qd0.6
+----------- 
+
+Added:
+- Muxing for the TTL inputs which with the 0.7.1 pyxspress release of configuration files
+  allows TTL in 0 and TTL in 1 to be recorded in the dataset.
+
 
 0.5.0+qd0.5
 -----------

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,8 +3,29 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
-0.5.0qd0-1
-----------
+0.5.0+qd0.2
+-----------
+
+Added:
+
+- Initial version of X3X2 processor plugin. This produces 1D frames containing
+  three elements per event as time_frame, time_stamp and event_height.
+
+Fixed:
+
+- Detector status now goes idle when stopping acquisition in X3X2 list mode
+
+Changed:
+
+- Enabled X3X2 list mode receiver plugins
+- The Xspress FP adapter now hard-codes the number of HDF5 frames to 0
+  and sends the number of frames to the processors. These are configured
+  with the number of time frames to collect and will stop the acquisition.
+  Zero frames to collect will mean continuous processing.
+
+
+0.5.0+qd0.1
+-----------
 
 Added:
 
@@ -13,10 +34,13 @@ Added:
 Changed:
 
 - C++ control server
+
   - now configures X3X2 clocks
   - now enables resets in list mode
   - Xspress library configure call explicitly requests list readout mode
+
 - Python control server
+
   - requests X3X2 list mode decoder plugin on configure to list mode
   - changed number of channels used in list mode
   - changed frame receiver IP/port configuration (currently listens to

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -4,6 +4,34 @@ Change log
 Changes made by Quantum Detectors to this repository are recorded below.
 
 
+0.5.0+qd0.4
+-----------
+
+Changed:
+
+- Separated out X3X2 list mode datasets to 1 dataset per event field. The memory
+  block has been split up into a base class and derived classes to manage the
+  different datatypes used for each field. The datasets created are:
+
+  - chX_time_frame (uint64)
+  - chX_time_stamp (uint64)
+  - chX_event_height (uint16)
+  - chX_reset_flag (uint8)
+
+- Changed how the X3X2 list mode plugin tracks acquisition completion
+  as we receive multiple events with the end of frame marker set. Now
+  use a map to track individual channel completion. The additional
+  events are currently ignored.
+- The X3X2 list mode processor plugin now sets the size of each memory
+  block based on number of events stored (versus using bytes). The `frame_size`
+  option under `xspress-list` in the JSON configuration file is used to define
+  the number of events per memory block frame.
+
+Fixed:
+
+- Fixed issue with parsing the time frame bits in the X3X2 list mode plugin
+
+
 0.5.0+qd0.3
 -----------
 

--- a/cpp/common/include/X3X2Definitions.h
+++ b/cpp/common/include/X3X2Definitions.h
@@ -1,0 +1,11 @@
+/**
+ * Definitions specific to the X3X2 cards
+ */
+
+#ifndef _X3X2DEFINITIONS_H
+#define _X3X2DEFINITIONS_H
+
+#define X3X2_MINI_TCP_FRAME_SIZE    8192
+#define X3X2_MINI_FIELDS_PER_FRAME  4096
+
+#endif

--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -183,6 +183,8 @@ public:
   virtual int set_window(int chan, int sca, int llm, int hlm) = 0;
   virtual int set_sca_thresh(int chan, int value) = 0;
   virtual int set_trigger_input(bool list_mode) = 0;
+  virtual int setup_clocks(int num_cards) = 0;
+  virtual int enable_list_mode_resets() = 0;
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -186,6 +186,7 @@ public:
   virtual int set_trigger_input(bool list_mode) = 0;
   virtual int setup_clocks(int num_cards) = 0;
   virtual int enable_list_mode_resets() = 0;
+  virtual int set_channel_sources(int run_flags) = 0;
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -155,6 +155,7 @@ public:
   virtual int histogram_continue(int card) = 0;
   virtual int histogram_pause(int card) = 0;
   virtual int histogram_stop(int card) = 0;
+  virtual int histogram_is_any_busy() = 0;
   virtual int string_trigger_mode_to_int(const std::string& mode) = 0;
   virtual int scaler_read(uint32_t *buffer,
                   uint32_t tf,

--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -187,6 +187,7 @@ public:
   virtual int setup_clocks(int num_cards) = 0;
   virtual int enable_list_mode_resets() = 0;
   virtual int set_channel_sources(int run_flags) = 0;
+  virtual int setup_marker_channels() = 0;
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -157,6 +157,7 @@ public:
   int set_trigger_input(bool list_mode);
   int setup_clocks(int num_cards);
   int enable_list_mode_resets();
+  int set_channel_sources(int run_flags);
 
 private:
   /** String representation of trigger modes */

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -126,6 +126,7 @@ public:
   int histogram_continue(int card);
   int histogram_pause(int card);
   int histogram_stop(int card);
+  int histogram_is_any_busy();
   int string_trigger_mode_to_int(const std::string& mode);
   int scaler_read(uint32_t *buffer,
                   uint32_t tf,

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -154,6 +154,8 @@ public:
   int set_window(int chan, int sca, int llm, int hlm);
   int set_sca_thresh(int chan, int value);
   int set_trigger_input(bool list_mode);
+  int setup_clocks(int num_cards);
+  int enable_list_mode_resets();
 
 private:
   /** String representation of trigger modes */

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -158,6 +158,7 @@ public:
   int setup_clocks(int num_cards);
   int enable_list_mode_resets();
   int set_channel_sources(int run_flags);
+  int setup_marker_channels();
 
 private:
   /** String representation of trigger modes */

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -194,6 +194,7 @@ public:
   int setup_clocks(int num_cards);
   int enable_list_mode_resets();
   int set_channel_sources(int run_flags);
+  int setup_marker_channels();
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -162,6 +162,7 @@ public:
   int histogram_continue(int card);
   int histogram_pause(int card);
   int histogram_stop(int card);
+  int histogram_is_any_busy();
   int string_trigger_mode_to_int(const std::string& mode);
   int scaler_read(uint32_t *buffer,
                   uint32_t tf,

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -193,6 +193,7 @@ public:
   int set_trigger_input(bool list_mode);
   int setup_clocks(int num_cards);
   int enable_list_mode_resets();
+  int set_channel_sources(int run_flags);
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -190,6 +190,8 @@ public:
   int set_window(int chan, int sca, int llm, int hlm);
   int set_sca_thresh(int chan, int value);
   int set_trigger_input(bool list_mode);
+  int setup_clocks(int num_cards);
+  int enable_list_mode_resets();
 
   static const int runFlag_MCA_SPECTRA_;
   static const int runFlag_SCALERS_ONLY_;

--- a/cpp/control/include/XspressDetector.h
+++ b/cpp/control/include/XspressDetector.h
@@ -61,6 +61,8 @@ public:
   bool checkConnected();
   int disconnect();
   int setupChannels();
+  int setupClocks();
+  int setupControlRegister();
   int enableDAQ();
   int checkSaveDir(const std::string& dir_name);
   int saveSettings();

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -607,6 +607,7 @@ int LibXspressSimulator::get_num_frames_read(int32_t *frames)
 int LibXspressSimulator::get_num_scalars(uint32_t *num_scalars)
 {
   *num_scalars = XSP3_SW_NUM_SCALERS;
+  return XSP_STATUS_OK;
 }
 
 int LibXspressSimulator::histogram_circ_ack(int channel,
@@ -615,13 +616,6 @@ int LibXspressSimulator::histogram_circ_ack(int channel,
                                           uint32_t max_channels)
 {
   int status = XSP_STATUS_OK;
-  /*
-  int xsp_status = xsp3_histogram_circ_ack(xsp_handle_, channel, frame_number, max_channels, number_of_frames);
-  if (xsp_status < XSP3_OK) {
-    checkErrorCode("xsp3_histogram_circ_ack", xsp_status);
-    status = XSP_STATUS_ERROR;
-  }
-  */
   return status;
 }
 
@@ -700,6 +694,12 @@ int LibXspressSimulator::histogram_stop(int card)
   }
   */
   return status;
+}
+
+int LibXspressSimulator::histogram_is_any_busy()
+{
+  // 0 indicates idle
+  return 0;
 }
 
 int LibXspressSimulator::string_trigger_mode_to_int(const std::string& mode)

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -957,4 +957,16 @@ int LibXspressSimulator::set_trigger_input(bool list_mode)
   return XSP_STATUS_OK;
 }
 
+int LibXspressSimulator::setup_clocks(int num_cards)
+{
+  // This is a no op for the simulator
+  return XSP_STATUS_OK;
+}
+
+int LibXspressSimulator::enable_list_mode_resets()
+{
+  // This is a no op for the simulator
+  return XSP_STATUS_OK;
+}
+
 } /* namespace Xspress */

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -969,4 +969,10 @@ int LibXspressSimulator::enable_list_mode_resets()
   return XSP_STATUS_OK;
 }
 
+int LibXspressSimulator::set_channel_sources(int run_flags)
+{
+  // This is a no op for the simulator
+  return XSP_STATUS_OK;
+}
+
 } /* namespace Xspress */

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -975,4 +975,10 @@ int LibXspressSimulator::set_channel_sources(int run_flags)
   return XSP_STATUS_OK;
 }
 
+int LibXspressSimulator::setup_marker_channels()
+{
+  // This is a no op for the simulator
+  return XSP_STATUS_OK;
+}
+
 } /* namespace Xspress */

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1193,7 +1193,6 @@ int LibXspressWrapper::set_trigger_input(bool list_mode)
   memset(&trig_mux, 0, sizeof(Xsp3TriggerMux));
   LOG4CXX_INFO(logger_, "list mode: " << list_mode << ", setting trigger inputs accordingly");
   if (list_mode){
-    // TODO: Ben: check if these are correct
     trig_mux.trig_sel[0] = 0;
     trig_mux.trig_sel[1] = 1;
     trig_mux.trig_sel[2] = 0;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 #include "dirent.h"
+#include <iostream>
 
 #include "LibXspressWrapper.h"
 #include "DebugLevelLogger.h"
@@ -1190,19 +1191,28 @@ int LibXspressWrapper::set_trigger_input(bool list_mode)
   int xsp_status;
   Xsp3TriggerMux trig_mux;
   memset(&trig_mux, 0, sizeof(Xsp3TriggerMux));
-
+  LOG4CXX_INFO(logger_, "list mode: " << list_mode << ", setting trigger inputs accordingly");
   if (list_mode){
     // TODO: Ben: check if these are correct
     trig_mux.trig_sel[0] = 0;
-    trig_mux.trig_sel[1] = 2;
-    trig_mux.trig_sel[2] = 1;
-    trig_mux.trig_sel[3] = 0;
+    trig_mux.trig_sel[1] = 1;
+    trig_mux.trig_sel[2] = 0;
+    trig_mux.trig_sel[3] = 1;
+    LOG4CXX_INFO(logger_, "Setting trigger inputs for list mode: "
+         << trig_mux.trig_sel[0] << ", "
+         << trig_mux.trig_sel[1] << ", "
+         << trig_mux.trig_sel[2] << ", "
+         << trig_mux.trig_sel[3]);
   } else {
     for (int i = 0; i < 4; i++){
       trig_mux.trig_sel[i] = i;
     }
   }
-
+  xsp_status = xsp3_set_glob_trigger_select(0, 0, &trig_mux);
+  if (xsp_status != XSP3_OK) {
+    checkErrorCode("xsp3_set_trigger_mux", xsp_status, true);
+    status = XSP_STATUS_ERROR;
+  }
   return status;
 }
 

--- a/cpp/control/src/XspressController.cpp
+++ b/cpp/control/src/XspressController.cpp
@@ -774,6 +774,22 @@ void XspressController::configureCommand(OdinData::IpcMessage& config, OdinData:
       // Command failed, return error with any error string
       reply.set_nack(xsp_->getErrorString());
       setError(xsp_->getErrorString());
+    } else {
+      // Configure the clock signals (important for Mk2)
+      status = xsp_->setupClocks();
+    }
+    if (status != XSP_STATUS_OK){
+      // Command failed, return error with any error string
+      reply.set_nack(xsp_->getErrorString());
+      setError(xsp_->getErrorString());
+    } else {
+      // Configure the control register (important for Mk2)
+      status = xsp_->setupControlRegister();
+    }
+    if (status != XSP_STATUS_OK){
+      // Command failed, return error with any error string
+      reply.set_nack(xsp_->getErrorString());
+      setError(xsp_->getErrorString());
     }
   }
 

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -211,6 +211,48 @@ int XspressDetector::setupChannels()
   return status;
 }
 
+int XspressDetector::setupClocks()
+{
+  int status = XSP_STATUS_OK;
+  if (checkConnected()){
+    status = detector_->setup_clocks(xsp_num_cards_);
+    if (status != XSP_STATUS_OK)
+    {
+      setErrorString("Failed to configure card clocks");
+    }
+  } else {
+    LOG4CXX_INFO(logger_, "Cannot set up clocks as not connected");
+    status = XSP_STATUS_ERROR;
+  }
+  return status;
+}
+
+/**
+ * @brief Set up the control register values
+ *
+ * - Enables resets if using X3X2 list mode
+ *
+ * @return int Whether we are successful
+ */
+int XspressDetector::setupControlRegister()
+{
+  int status = XSP_STATUS_OK;
+  if (checkConnected()){
+    if (xsp_mode_ == XSP_MODE_LIST)
+    {
+      status = detector_->enable_list_mode_resets();
+      if (status != XSP_STATUS_OK)
+      {
+        setErrorString("Failed to configure list mode resets");
+      }
+    }
+  } else {
+    LOG4CXX_INFO(logger_, "Cannot set up control register as not connected");
+    status = XSP_STATUS_ERROR;
+  }
+  return status;
+}
+
 int XspressDetector::enableDAQ()
 {
   int status = XSP_STATUS_OK;
@@ -545,6 +587,7 @@ int XspressDetector::sendSoftwareTrigger()
 {
   int status = XSP_STATUS_OK;
   if (acquiring_){
+    // TODO: BEN: handle what happens in list mode if required
     if (xsp_trigger_mode_ == TM_SOFTWARE){
       status = detector_->histogram_continue(0);
       status |= detector_->histogram_pause(0);

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -382,6 +382,14 @@ int XspressDetector::restoreSettings()
     }
   }
 
+  // Configure marker channels
+  if (status == XSP_STATUS_OK){
+    status = detector_->setup_marker_channels();
+    if (status != XSP_STATUS_OK){
+      setErrorString(detector_->getErrorString());
+    }
+  }
+
   // Read existing SCA params
   if (status == XSP_STATUS_OK){
     status = readSCAParams();

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -24,6 +24,7 @@ XspressDetector::XspressDetector(bool simulation) :
     logger_(log4cxx::Logger::getLogger("Xspress.XspressDetector")),
     simulated_(simulation),
     connected_(false),
+    acquiring_(false),
     reconnect_required_(false),
     acq_failed_(false),
     xsp_num_cards_(0),
@@ -579,6 +580,9 @@ int XspressDetector::stopAcquisition()
       }
     }
     status = detector_->histogram_stop(-1);
+
+    // We can return to idle immediately after stopping hist in list mode
+    if (xsp_mode_ == XSP_MODE_LIST) acquiring_ = false;
   }
   return status;
 }

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -374,6 +374,14 @@ int XspressDetector::restoreSettings()
     }
   }
 
+  // Setup channel data sources
+  if (status == XSP_STATUS_OK){
+    status = detector_->set_channel_sources(xsp_run_flags_);
+    if (status != XSP_STATUS_OK){
+      setErrorString(detector_->getErrorString());
+    }
+  }
+
   // Read existing SCA params
   if (status == XSP_STATUS_OK){
     status = readSCAParams();

--- a/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeMemoryBlocks.h
@@ -1,0 +1,98 @@
+#ifndef SRC_X3X2LISTMODEMEMORYBLOCK_H
+#define SRC_X3X2LISTMODEMEMORYBLOCK_H
+
+#include <log4cxx/logger.h>
+#include <log4cxx/basicconfigurator.h>
+#include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/helpers/exception.h>
+
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+
+#include "FrameProcessorPlugin.h"
+#include "gettime.h"
+
+namespace FrameProcessor
+{
+
+  /**
+   * Generic class for managing a block of memory containing a single field
+   * of list mode data.
+   */
+  class X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeMemoryBlock(const std::string& name, DataType data_type, uint32_t num_bytes_per_event);
+    virtual ~X3X2ListModeMemoryBlock();
+    void set_size(uint32_t bytes);
+    void reallocate();
+    void reset();
+    void reset_frame_count();
+    boost::shared_ptr <Frame> to_frame();
+    boost::shared_ptr <Frame> flush();
+
+  protected:
+    void *ptr_;
+    std::string name_;
+    uint32_t num_bytes_;
+    uint32_t filled_size_;
+    uint32_t frame_count_;
+
+    DataType data_type_;
+    uint32_t num_bytes_per_event_;
+
+    /** Pointer to logger */
+    LoggerPtr logger_;
+  };
+
+  /**
+   * Specific class for managing timeframe memory blocks
+   */
+  class X3X2ListModeTimeframeMemoryBlock :  public X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeTimeframeMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeTimeframeMemoryBlock();
+
+    boost::shared_ptr <Frame> add_timeframe(uint64_t timeframe);
+  };
+
+  /**
+   * Specific class for managing timestamp memory blocks
+   */
+  class X3X2ListModeTimestampMemoryBlock :  public X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeTimestampMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeTimestampMemoryBlock();
+
+    boost::shared_ptr <Frame> add_timestamp(uint64_t timestamp);
+  };
+
+  /**
+   * Specific class for managing event height memory blocks
+   */
+  class X3X2ListModeEventHeightMemoryBlock :  public X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeEventHeightMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeEventHeightMemoryBlock();
+
+    boost::shared_ptr <Frame> add_event_height(uint16_t event_height);
+  };
+
+  /**
+   * Specific class for managing event reset flag memory blocks
+   */
+  class X3X2ListModeResetFlagMemoryBlock :  public X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeResetFlagMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeResetFlagMemoryBlock();
+
+    boost::shared_ptr <Frame> add_reset_flag(uint8_t reset_flag);
+  };
+
+}
+
+#endif //SRC_X3X2LISTMODEMEMORYBLOCK_H

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -1,0 +1,102 @@
+
+#ifndef SRC_X3X2LISTMODEPLUGIN_H
+#define SRC_X3X2LISTMODEPLUGIN_H
+
+#include <log4cxx/logger.h>
+#include <log4cxx/basicconfigurator.h>
+#include <log4cxx/propertyconfigurator.h>
+#include <log4cxx/helpers/exception.h>
+
+using namespace log4cxx;
+using namespace log4cxx::helpers;
+
+#include "FrameProcessorPlugin.h"
+#include "XspressDefinitions.h"
+#include "gettime.h"
+
+namespace FrameProcessor
+{
+
+  class X3X2ListModeMemoryBlock
+  {
+  public:
+    X3X2ListModeMemoryBlock(const std::string& name);
+    virtual ~X3X2ListModeMemoryBlock();
+    void set_size(uint32_t bytes);
+    void reallocate();
+    void reset();
+    void reset_frame_count();
+    boost::shared_ptr <Frame> add_event(uint64_t time_frame, uint64_t time_stamp, uint64_t event_height);
+    boost::shared_ptr <Frame> to_frame();
+    boost::shared_ptr <Frame> flush();
+
+  private:
+    void *ptr_;
+    std::string name_;
+    uint32_t num_bytes_;
+    uint32_t filled_size_;  // Filled size in bytes
+    uint32_t frame_count_;
+
+    const uint32_t num_bytes_per_event_ = 24;
+
+    /** Pointer to logger */
+    LoggerPtr logger_;
+  };
+
+  class X3X2ListModeProcessPlugin : public FrameProcessorPlugin 
+  {
+  public:
+    X3X2ListModeProcessPlugin();
+
+    virtual ~X3X2ListModeProcessPlugin();
+
+    void configure(OdinData::IpcMessage &config, OdinData::IpcMessage &reply);
+
+    // version related functions
+    int get_version_major();
+
+    int get_version_minor();
+
+    int get_version_patch();
+
+    std::string get_version_short();
+
+    std::string get_version_long();
+
+  private:
+
+    void reset_acquisition();
+    void flush_close_acquisition();
+    void set_channels(std::vector<uint32_t> channels);
+    void set_frame_size(uint32_t num_bytes);
+    void setup_memory_allocation();
+        
+    // Plugin interface
+    void status(OdinData::IpcMessage& status);
+    void process_frame(boost::shared_ptr <Frame> frame);
+
+    uint32_t frame_size_bytes_;
+    std::vector<uint32_t> channels_;
+    uint32_t num_channels_;
+    uint32_t channel_offset_;
+
+    uint32_t num_time_frames_;
+    uint32_t num_completed_channels_;
+
+    std::map<uint32_t, boost::shared_ptr<X3X2ListModeMemoryBlock> > memory_ptrs_;
+    std::map<uint32_t, std::vector<uint32_t> > packet_headers_;
+
+    static const std::string CONFIG_CHANNELS;
+    static const std::string CONFIG_RESET_ACQUISITION;
+    static const std::string CONFIG_FLUSH_ACQUISITION;
+    static const std::string CONFIG_FRAME_SIZE;
+    static const std::string CONFIG_TIME_FRAMES;
+
+    /** Pointer to logger */
+    LoggerPtr logger_;
+  };
+
+}
+
+
+#endif //SRC_X3X2LISTMODEPLUGIN_H

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -70,6 +70,10 @@ namespace FrameProcessor
     uint32_t num_channels_;
     uint32_t channel_offset_;
 
+    // Whether marker channels are enabled
+    bool marker_channels_enabled_;
+    std::vector<uint32_t> marker_channels_;
+
     // Acquisition properties
     uint32_t num_time_frames_;
     bool acquisition_complete_;
@@ -89,6 +93,7 @@ namespace FrameProcessor
     std::map<uint32_t, std::vector<uint32_t> > packet_headers_;
 
     static const std::string CONFIG_CHANNELS;
+    static const std::string CONFIG_MARKERS_ENABLED;
     static const std::string CONFIG_RESET_ACQUISITION;
     static const std::string CONFIG_FLUSH_ACQUISITION;
     static const std::string CONFIG_FRAME_SIZE;

--- a/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/X3X2ListModeProcessPlugin.h
@@ -77,6 +77,8 @@ namespace FrameProcessor
     // Tracking per channel
     std::map<uint32_t, bool> completed_channels_;
     std::map<uint32_t, uint64_t> num_events_;
+    std::map<uint32_t, uint64_t> prev_time_frames_;
+    std::map<uint32_t, uint64_t> prev_time_stamps_;
 
     // Memory blocks for event fields
     std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock> > timeframe_memory_ptrs_;

--- a/cpp/data/frameProcessor/src/CMakeLists.txt
+++ b/cpp/data/frameProcessor/src/CMakeLists.txt
@@ -10,6 +10,10 @@ target_link_libraries(XspressProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIE
 add_library(XspressListModeProcessPlugin SHARED XspressListModeProcessPlugin.cpp XspressListModeProcessPluginLib.cpp)
 target_link_libraries(XspressListModeProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 
+# Add library for X3X2 list mode process plugin
+add_library(X3X2ListModeProcessPlugin SHARED X3X2ListModeProcessPlugin.cpp X3X2ListModeProcessPluginLib.cpp)
+target_link_libraries(X3X2ListModeProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
+
 install(TARGETS XspressProcessPlugin
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
@@ -20,3 +24,7 @@ install(TARGETS XspressListModeProcessPlugin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
+install(TARGETS X3X2ListModeProcessPlugin
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)

--- a/cpp/data/frameProcessor/src/CMakeLists.txt
+++ b/cpp/data/frameProcessor/src/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(XspressListModeProcessPlugin SHARED XspressListModeProcessPlugin.cpp
 target_link_libraries(XspressListModeProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 
 # Add library for X3X2 list mode process plugin
-add_library(X3X2ListModeProcessPlugin SHARED X3X2ListModeProcessPlugin.cpp X3X2ListModeProcessPluginLib.cpp)
+add_library(X3X2ListModeProcessPlugin SHARED X3X2ListModeProcessPlugin.cpp X3X2ListModeProcessPluginLib.cpp X3X2ListModeMemoryBlocks.cpp)
 target_link_libraries(X3X2ListModeProcessPlugin ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5HL_LIBRARIES} ${COMMON_LIBRARY})
 
 install(TARGETS XspressProcessPlugin

--- a/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
@@ -1,0 +1,251 @@
+#include <iostream>
+
+#include "DataBlockFrame.h"
+#include "DebugLevelLogger.h"
+
+#include "X3X2ListModeMemoryBlocks.h"
+#include "FrameProcessorDefinitions.h"
+
+namespace FrameProcessor {
+
+// ============================================================================
+// Base memory block class
+// ============================================================================
+
+X3X2ListModeMemoryBlock::X3X2ListModeMemoryBlock(
+    const std::string& name,
+    DataType data_type,
+    uint32_t num_bytes_per_event
+  ) :
+  ptr_(0),
+  num_bytes_(0),
+  filled_size_(0),
+  frame_count_(0),
+  data_type_(data_type),
+  num_bytes_per_event_(num_bytes_per_event)
+{
+  name_ = name;
+
+  // Setup logging for the class
+  logger_ = Logger::getLogger("FP.X3X2ListModeProcessPlugin");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeMemoryBlock");
+}
+
+X3X2ListModeMemoryBlock::~X3X2ListModeMemoryBlock()
+{
+  if (ptr_){
+    free(ptr_);
+  }
+}
+
+/**
+ * Set the size of the memory block in bytes.
+ */
+void X3X2ListModeMemoryBlock::set_size(uint32_t bytes)
+{
+  // Round allocation down to number of whole events
+  num_bytes_ = (bytes/num_bytes_per_event_)*num_bytes_per_event_;
+  reallocate();
+}
+
+void X3X2ListModeMemoryBlock::reallocate()
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Reallocating X3X2ListModeMemoryBlock to [" << num_bytes_ << "] bytes");
+  if (ptr_){
+    free(ptr_);
+  }
+  ptr_ = (char *)malloc(num_bytes_);
+  reset();
+}
+
+void X3X2ListModeMemoryBlock::reset()
+{
+  memset(ptr_, 0, num_bytes_);
+  filled_size_ = 0;
+}
+
+void X3X2ListModeMemoryBlock::reset_frame_count()
+{
+  frame_count_ = 0;
+}
+
+boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Getting complete frame " << frame_count_ << " of " << num_bytes_ << " bytes");
+  boost::shared_ptr <Frame> frame;
+
+  // Create the frame around the complete block
+  dimensions_t dims;
+  FrameMetaData list_metadata(frame_count_, name_, data_type_, "", dims);
+  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, ptr_, num_bytes_));
+
+  // Reset the block
+  reset();
+
+  // Add 1 to the frame count
+  frame_count_++;
+
+  return frame;
+}
+
+boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::flush()
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Flushing partial frame " << frame_count_ << " of " << filled_size_ << " bytes");
+  boost::shared_ptr <Frame> frame;
+
+  // Create the frame around the current (partial) block
+  dimensions_t dims;
+  FrameMetaData list_metadata(frame_count_, name_, data_type_, "", dims);
+  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, ptr_, filled_size_));
+
+  // We don't reset here as this is called at the end of an acquisition by
+  // flush_close_acquisition. Resetting should reset the memory block before
+  // the next one starts
+
+  return frame;
+}
+
+
+// ============================================================================
+// Timeframe memory block
+// ============================================================================
+
+X3X2ListModeTimeframeMemoryBlock::X3X2ListModeTimeframeMemoryBlock(const std::string& name) :
+    X3X2ListModeMemoryBlock(name, raw_64bit, 8)
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeTimeframeMemoryBlock");
+}
+
+X3X2ListModeTimeframeMemoryBlock::~X3X2ListModeTimeframeMemoryBlock()
+{
+}
+
+boost::shared_ptr <Frame> X3X2ListModeTimeframeMemoryBlock::add_timeframe(uint64_t timeframe)
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Calculate the current end of data pointer location
+  char *dest = (char *)ptr_;
+  dest += filled_size_;
+
+  // Add the event
+  *((uint64_t *)dest) = timeframe;
+
+  filled_size_ += sizeof(uint64_t);
+
+  // Final check, if we have a full buffer then send it out
+  if (filled_size_ == num_bytes_){
+    frame = this->to_frame();
+  }
+
+  return frame;
+}
+
+
+// ============================================================================
+// Timestamp memory block
+// ============================================================================
+
+X3X2ListModeTimestampMemoryBlock::X3X2ListModeTimestampMemoryBlock(const std::string& name) :
+    X3X2ListModeMemoryBlock(name, raw_64bit, 8)
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeTimestampMemoryBlock");
+}
+
+X3X2ListModeTimestampMemoryBlock::~X3X2ListModeTimestampMemoryBlock()
+{
+}
+
+boost::shared_ptr <Frame> X3X2ListModeTimestampMemoryBlock::add_timestamp(uint64_t timestamp)
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Calculate the current end of data pointer location
+  char *dest = (char *)ptr_;
+  dest += filled_size_;
+
+  // Add the event
+  *((uint64_t *)dest) = timestamp;
+
+  filled_size_ += sizeof(uint64_t);
+
+  // Final check, if we have a full buffer then send it out
+  if (filled_size_ == num_bytes_){
+    frame = this->to_frame();
+  }
+
+  return frame;
+}
+
+
+// ============================================================================
+// Event height memory block
+// ============================================================================
+
+X3X2ListModeEventHeightMemoryBlock::X3X2ListModeEventHeightMemoryBlock(const std::string& name) :
+    X3X2ListModeMemoryBlock(name, raw_16bit, 2)
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeEventHeightMemoryBlock");
+}
+
+X3X2ListModeEventHeightMemoryBlock::~X3X2ListModeEventHeightMemoryBlock()
+{
+}
+
+boost::shared_ptr <Frame> X3X2ListModeEventHeightMemoryBlock::add_event_height(uint16_t event_height)
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Calculate the current end of data pointer location
+  char *dest = (char *)ptr_;
+  dest += filled_size_;
+
+  // Add the event
+  *((uint16_t *)dest) = event_height;
+
+  filled_size_ += sizeof(uint16_t);
+
+  // Final check, if we have a full buffer then send it out
+  if (filled_size_ == num_bytes_){
+    frame = this->to_frame();
+  }
+
+  return frame;
+}
+
+// ============================================================================
+// Reset flag memory block
+// ============================================================================
+
+X3X2ListModeResetFlagMemoryBlock::X3X2ListModeResetFlagMemoryBlock(const std::string& name) :
+    X3X2ListModeMemoryBlock(name, raw_8bit, 1)
+{
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeResetFlagMemoryBlock");
+}
+
+X3X2ListModeResetFlagMemoryBlock::~X3X2ListModeResetFlagMemoryBlock()
+{
+}
+
+boost::shared_ptr <Frame> X3X2ListModeResetFlagMemoryBlock::add_reset_flag(uint8_t reset_flag)
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Calculate the current end of data pointer location
+  char *dest = (char *)ptr_;
+  dest += filled_size_;
+
+  // Add the event
+  *((uint8_t *)dest) = reset_flag;
+
+  filled_size_ += sizeof(uint8_t);
+
+  // Final check, if we have a full buffer then send it out
+  if (filled_size_ == num_bytes_){
+    frame = this->to_frame();
+  }
+
+  return frame;
+}
+
+}

--- a/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeMemoryBlocks.cpp
@@ -28,7 +28,7 @@ X3X2ListModeMemoryBlock::X3X2ListModeMemoryBlock(
 
   // Setup logging for the class
   logger_ = Logger::getLogger("FP.X3X2ListModeProcessPlugin");
-  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeMemoryBlock");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Created X3X2ListModeMemoryBlock");
 }
 
 X3X2ListModeMemoryBlock::~X3X2ListModeMemoryBlock()
@@ -113,7 +113,7 @@ boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::flush()
 X3X2ListModeTimeframeMemoryBlock::X3X2ListModeTimeframeMemoryBlock(const std::string& name) :
     X3X2ListModeMemoryBlock(name, raw_64bit, 8)
 {
-  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeTimeframeMemoryBlock");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Created X3X2ListModeTimeframeMemoryBlock");
 }
 
 X3X2ListModeTimeframeMemoryBlock::~X3X2ListModeTimeframeMemoryBlock()
@@ -149,7 +149,7 @@ boost::shared_ptr <Frame> X3X2ListModeTimeframeMemoryBlock::add_timeframe(uint64
 X3X2ListModeTimestampMemoryBlock::X3X2ListModeTimestampMemoryBlock(const std::string& name) :
     X3X2ListModeMemoryBlock(name, raw_64bit, 8)
 {
-  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeTimestampMemoryBlock");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Created X3X2ListModeTimestampMemoryBlock");
 }
 
 X3X2ListModeTimestampMemoryBlock::~X3X2ListModeTimestampMemoryBlock()
@@ -185,7 +185,7 @@ boost::shared_ptr <Frame> X3X2ListModeTimestampMemoryBlock::add_timestamp(uint64
 X3X2ListModeEventHeightMemoryBlock::X3X2ListModeEventHeightMemoryBlock(const std::string& name) :
     X3X2ListModeMemoryBlock(name, raw_16bit, 2)
 {
-  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeEventHeightMemoryBlock");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Created X3X2ListModeEventHeightMemoryBlock");
 }
 
 X3X2ListModeEventHeightMemoryBlock::~X3X2ListModeEventHeightMemoryBlock()
@@ -220,7 +220,7 @@ boost::shared_ptr <Frame> X3X2ListModeEventHeightMemoryBlock::add_event_height(u
 X3X2ListModeResetFlagMemoryBlock::X3X2ListModeResetFlagMemoryBlock(const std::string& name) :
     X3X2ListModeMemoryBlock(name, raw_8bit, 1)
 {
-  LOG4CXX_INFO(logger_, "[" << name_ << "]" << "Created X3X2ListModeResetFlagMemoryBlock");
+  LOG4CXX_INFO(logger_, "[" << name_ << "]" << " Created X3X2ListModeResetFlagMemoryBlock");
 }
 
 X3X2ListModeResetFlagMemoryBlock::~X3X2ListModeResetFlagMemoryBlock()

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -1,0 +1,438 @@
+#include <iostream>
+#include "DataBlockFrame.h"
+#include "X3X2ListModeProcessPlugin.h"
+#include "FrameProcessorDefinitions.h"
+#include "X3X2Definitions.h"
+#include "DebugLevelLogger.h"
+
+
+namespace FrameProcessor {
+
+const std::string X3X2ListModeProcessPlugin::CONFIG_CHANNELS =           "channels";
+const std::string X3X2ListModeProcessPlugin::CONFIG_RESET_ACQUISITION =  "reset";
+const std::string X3X2ListModeProcessPlugin::CONFIG_FLUSH_ACQUISITION =  "flush";
+const std::string X3X2ListModeProcessPlugin::CONFIG_FRAME_SIZE =         "frame_size";
+const std::string X3X2ListModeProcessPlugin::CONFIG_TIME_FRAMES =        "time_frames";
+
+X3X2ListModeMemoryBlock::X3X2ListModeMemoryBlock(const std::string& name) :
+  ptr_(0),
+  num_bytes_(0),
+  filled_size_(0),
+  frame_count_(0)
+{
+  // Setup logging for the class
+  logger_ = Logger::getLogger("FP.X3X2ListModeProcessPlugin");
+  LOG4CXX_INFO(logger_, "Created X3X2ListModeMemoryBlock");
+
+  name_ = name;
+}
+
+X3X2ListModeMemoryBlock::~X3X2ListModeMemoryBlock()
+{
+  if (ptr_){
+    free(ptr_);
+  }
+}
+
+void X3X2ListModeMemoryBlock::set_size(uint32_t bytes)
+{
+  // Round allocation down to number of whole events
+  num_bytes_ = (bytes/num_bytes_per_event_)*num_bytes_per_event_;
+  reallocate();
+}
+
+void X3X2ListModeMemoryBlock::reallocate()
+{
+  LOG4CXX_INFO(logger_, "Reallocating X3X2ListModeMemoryBlock to [" << num_bytes_ << "] bytes");
+  if (ptr_){
+    free(ptr_);
+  }
+  ptr_ = (char *)malloc(num_bytes_);
+  reset();
+}
+
+void X3X2ListModeMemoryBlock::reset()
+{
+  memset(ptr_, 0, num_bytes_);
+  filled_size_ = 0;
+}
+
+void X3X2ListModeMemoryBlock::reset_frame_count()
+{
+  frame_count_ = 0;
+}
+
+boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::add_event(uint64_t time_frame, uint64_t time_stamp, uint64_t event_height)
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Calculate the current end of data pointer location
+  char *dest = (char *)ptr_;
+  dest += filled_size_;
+
+  // Add the event
+  // *(reinterpret_cast<uint64_t>(dest)) = event_height;
+  *((uint64_t *)dest) = time_frame;
+  *((uint64_t *)(dest) + 1) = time_stamp;
+  *((uint64_t *)(dest) + 2) = event_height;
+
+  filled_size_ += 3*sizeof(uint64_t);
+
+  // Final check, if we have a full buffer then send it out
+  if (filled_size_ == num_bytes_){
+    frame = this->to_frame();
+  }
+
+  return frame;
+}
+
+boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Create the frame around the current (partial) block
+  dimensions_t dims;
+  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
+  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, num_bytes_));
+  memcpy(frame->get_data_ptr(), ptr_, num_bytes_);
+
+  // Reset the block
+  reset();
+
+  // Add 1 to the frame count
+  frame_count_++;
+
+  return frame;
+}
+
+boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::flush()
+{
+  boost::shared_ptr <Frame> frame;
+
+  // Create the frame around the current (partial) block
+  dimensions_t dims;
+  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
+  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, filled_size_));
+  memcpy(frame->get_data_ptr(), ptr_, filled_size_);
+
+  return frame;
+}
+
+X3X2ListModeProcessPlugin::X3X2ListModeProcessPlugin() :
+  num_channels_(0),
+  channel_offset_(0),
+  num_time_frames_(0),
+  num_completed_channels_(0)
+{
+  // Setup logging for the class
+  logger_ = Logger::getLogger("FP.X3X2ListModeProcessPlugin");
+  LOG4CXX_INFO(logger_, "X3X2ListModeProcessPlugin version " << this->get_version_long() << " loaded");
+}
+
+X3X2ListModeProcessPlugin::~X3X2ListModeProcessPlugin()
+{
+  LOG4CXX_TRACE(logger_, "X3X2ListModeProcessPlugin destructor.");
+}
+
+void X3X2ListModeProcessPlugin::configure(OdinData::IpcMessage& config, OdinData::IpcMessage& reply) 
+{
+  if (config.has_param(X3X2ListModeProcessPlugin::CONFIG_CHANNELS)){
+    std::stringstream ss;
+    ss << "Configure process plugin for channels [";
+    const rapidjson::Value& channels = config.get_param<const rapidjson::Value&>(X3X2ListModeProcessPlugin::CONFIG_CHANNELS);
+    std::vector<uint32_t> channel_vec;
+    size_t num_channels = channels.Size();
+    for (size_t i = 0; i < num_channels; i++) {
+      const rapidjson::Value& chan_value = channels[i];
+      channel_vec.push_back(chan_value.GetInt());
+      ss << chan_value.GetInt();
+      if (i < num_channels - 1){
+        ss << ", ";
+      }
+    }
+    ss << "]";
+    LOG4CXX_INFO(logger_, ss.str());
+    this->set_channels(channel_vec);
+  }
+
+  if (config.has_param(X3X2ListModeProcessPlugin::CONFIG_RESET_ACQUISITION)){
+    this->reset_acquisition();
+  }
+
+  if (config.has_param(X3X2ListModeProcessPlugin::CONFIG_FLUSH_ACQUISITION)){
+    this->flush_close_acquisition();
+  }
+
+  if (config.has_param(X3X2ListModeProcessPlugin::CONFIG_FRAME_SIZE)){
+    unsigned int frame_size = config.get_param<unsigned int>(X3X2ListModeProcessPlugin::CONFIG_FRAME_SIZE);
+    this->set_frame_size(frame_size);
+  }
+
+  if (config.has_param(X3X2ListModeProcessPlugin::CONFIG_TIME_FRAMES)){
+    num_time_frames_ = config.get_param<unsigned int>(X3X2ListModeProcessPlugin::CONFIG_TIME_FRAMES);
+    LOG4CXX_INFO(logger_, "Number of time frames has been set to  " << num_time_frames_);
+  }
+
+}
+
+// Version functions
+int X3X2ListModeProcessPlugin::get_version_major() 
+{
+  return XSPRESS_DETECTOR_VERSION_MAJOR;
+}
+
+int X3X2ListModeProcessPlugin::get_version_minor()
+{
+  return XSPRESS_DETECTOR_VERSION_MINOR;
+}
+
+int X3X2ListModeProcessPlugin::get_version_patch()
+{
+  return XSPRESS_DETECTOR_VERSION_PATCH;
+}
+
+std::string X3X2ListModeProcessPlugin::get_version_short()
+{
+  return XSPRESS_DETECTOR_VERSION_STR_SHORT;
+}
+
+std::string X3X2ListModeProcessPlugin::get_version_long()
+{
+  return XSPRESS_DETECTOR_VERSION_STR;
+}
+
+void X3X2ListModeProcessPlugin::set_channels(std::vector<uint32_t> channels)
+{
+  channels_ = channels;
+  num_channels_ = channels.size();
+  // TCP frames only report as channels 0 and 1 - we need to store
+  // the offset so we can report the correct system channels to the file
+  // writer
+  channel_offset_ = channels_[0];
+  // We must reallocate memory blocks
+  setup_memory_allocation();
+}
+
+void X3X2ListModeProcessPlugin::reset_acquisition()
+{
+  LOG4CXX_INFO(logger_, "Resetting acquisition");
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeMemoryBlock> >::iterator iter;
+  for (iter = memory_ptrs_.begin(); iter != memory_ptrs_.end(); ++iter){
+    iter->second->reset_frame_count();
+    iter->second->reset();
+  }
+
+  num_completed_channels_ = 0;
+}
+
+void X3X2ListModeProcessPlugin::flush_close_acquisition()
+{
+  LOG4CXX_INFO(logger_, "Flushing and closing acquisition");
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeMemoryBlock> >::iterator iter;
+  for (iter = memory_ptrs_.begin(); iter != memory_ptrs_.end(); ++iter){
+    LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing frame for channel " << iter->first);
+    boost::shared_ptr <Frame> list_frame = iter->second->to_frame();
+    if (list_frame){
+      this->push(list_frame);
+    }
+  }
+  this->notify_end_of_acquisition();
+}
+
+void X3X2ListModeProcessPlugin::set_frame_size(uint32_t num_bytes)
+{
+  LOG4CXX_INFO(logger_, "Setting frame size to " << num_bytes << " bytes");
+  frame_size_bytes_ = num_bytes;
+  // We must reallocate memory blocks
+  setup_memory_allocation();
+}
+
+void X3X2ListModeProcessPlugin::setup_memory_allocation()
+{
+  // First clear out the memory vector emptying any blocks
+  memory_ptrs_.clear();
+
+  // Allocate large enough blocks of memory to hold list mode frames
+  // Allocate one block of memory for each channel
+  std::vector<uint32_t>::iterator iter;
+  for (iter = channels_.begin(); iter != channels_.end(); ++iter){
+    std::stringstream ss;
+    ss << "raw_" << *iter;
+    boost::shared_ptr<X3X2ListModeMemoryBlock> ptr = boost::shared_ptr<X3X2ListModeMemoryBlock>(new X3X2ListModeMemoryBlock(ss.str()));
+    ptr->set_size(frame_size_bytes_);
+    memory_ptrs_[*iter] = ptr;
+    // Setup the storage vectors for the packet header information
+    std::vector<uint32_t> hdr(3, 0);
+    packet_headers_[*iter] = hdr;
+  }
+}
+
+/**
+ * Collate status information for the plugin. The status is added to the status IpcMessage object.
+ *
+ * \param[out] status - Reference to an IpcMessage value to store the status.
+ */
+void X3X2ListModeProcessPlugin::status(OdinData::IpcMessage& status)
+{
+  std::map<uint32_t, std::vector<uint32_t> >::iterator iter;
+  for (iter = packet_headers_.begin(); iter != packet_headers_.end(); ++iter){
+    std::stringstream ss;
+    ss << "channel_" << iter->first;
+    std::vector<uint32_t> hdr = iter->second;
+    for (int index = 0; index < hdr.size(); index++){
+      status.set_param(get_name() + "/" + ss.str() + "[]", hdr[index]);
+    }
+  }
+}
+
+void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame) 
+{
+  // LOG4CXX_INFO(logger_, "Processing frame " << frame->get_frame_number() << " of size " << frame->get_data_size() << " at " << frame->get_data_ptr());
+
+  uint16_t* frame_data = static_cast<uint16_t *>(frame->get_data_ptr());
+
+  // TODO: remove after testing
+  std::string ids("");
+  std::string values("");
+
+  // Event attributes
+  uint16_t acquisition_number = 0;
+  uint64_t time_frame = 0;
+  uint64_t time_stamp = 0;
+
+  uint64_t event_height = 0;
+
+  bool dummy_event = 0;
+  bool end_of_frame = 0;
+  bool ttl_a = 0;
+  bool ttl_b = 0;
+
+  uint16_t channel = -1;
+
+  // Track number of events
+  unsigned int num_events = 0;
+  unsigned int num_resets = 0;
+  unsigned int num_padding = 0;
+
+  uint16_t id;
+  uint16_t value;
+  uint64_t value_64;
+
+  for (unsigned int field = 0; field < X3X2_MINI_FIELDS_PER_FRAME; field++)
+  {
+    // Decode field
+    id = frame_data[field] >> 12;
+    value = frame_data[field] & 0xFFF;
+    value_64 = (uint64_t) value;
+
+    // TODO: remove after testing
+    //ids += std::to_string(id) + ",";
+    //values += std::to_string(value) + ",";
+
+    switch (id)
+    {
+      case 1:
+        acquisition_number = value;
+        break;
+      case 4:
+        end_of_frame = value & 0x1;
+        ttl_a = value & 0x2;
+        ttl_b = value & 0x4;
+        dummy_event = value & 0x8;
+        time_frame = (time_frame & 0xFFFFFFFFFFFFFF00) | (value_64 >> 4);
+        break;
+      case 5:
+        time_frame = (time_frame & 0xFFFFFFFFFFF000FF) | (value_64 << 8);
+        break;
+      case 6:
+        time_frame = (time_frame & 0xFFFFFFFF000FFFFF) | (value_64 << 20);
+        break;
+      case 7:
+        time_frame = (time_frame & 0xFFFFF000FFFFFFFF) | (value_64 << 32);
+        break;
+      case 8:
+        time_frame = (time_frame & 0xFF000FFFFFFFFFFF) | (value_64 << 44);
+        break;
+      case 9:
+        // Calculate actual channel in system
+        channel = (value >> 8) + channel_offset_;
+        // Check we have the right channel (and ignore markers)
+        if (memory_ptrs_.find(channel) == memory_ptrs_.end()) {
+          return;
+        }
+        time_frame = (time_frame & 0x00FFFFFFFFFFFFFF) | (value_64 << 56);
+        break;
+      case 10:
+        time_stamp = (time_stamp & 0xFFFFFFFFF000) | value_64;
+        break;
+      case 11:
+        time_stamp = (time_stamp & 0xFFFFFF000FFF) | (value_64 << 12);
+        break;
+      case 12:
+        time_stamp = (time_stamp & 0xFFF000FFFFFF) | (value_64 << 24);
+        break;
+      case 13:
+        time_stamp = (time_stamp & 0x000FFFFFFFFF) | (value_64 << 36);
+        break;
+      case 15:
+        num_padding++;
+        break;
+      case 14:
+        // Reset event width
+        num_resets++;
+        if (end_of_frame)
+        {
+          LOG4CXX_INFO(logger_, "Channel " << channel << " got end of frame for frame " << time_frame <<  " need: " << num_time_frames_);
+          if (time_frame + 1 == num_time_frames_)
+          {
+            LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames complete for channel " << channel);
+            num_completed_channels_++;
+          }
+        }
+        break;
+      case 0:
+        // Event height
+        event_height = value;
+
+        // TODO: account for dummy events
+
+        // TODO: remove when tested
+        //LOG4CXX_INFO(logger_, "Got values: " << time_frame << ", " << time_stamp << ", " << event_height << " for first event ");
+        //return
+
+        // Add event
+        boost::shared_ptr <Frame> list_frame = (memory_ptrs_[channel])->add_event(time_frame, time_stamp, event_height);
+        if (list_frame){
+          // LOG4CXX_DEBUG_LEVEL(1, logger_, "Completed frame for channel " << channel << ", pushing");
+          // There is a full frame available for pushing
+          this->push(list_frame);
+        }
+        if (end_of_frame)
+        {
+          LOG4CXX_INFO(logger_, "Channel " << channel << " got end of frame for frame " << time_frame);
+          if (time_frame + 1 == num_time_frames_)
+          {
+            LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames complete for channel " << channel);
+            num_completed_channels_++;
+          }
+        }
+        num_events++;
+        break;
+    }
+  }
+
+  if (num_completed_channels_ == num_channels_)
+  {
+    LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames completed for all channels");
+    this->flush_close_acquisition();
+  }
+
+  // TODO: remove after testing
+  //LOG4CXX_INFO(logger_, "Got ids " << ids << " for channel " << channel);
+  //LOG4CXX_INFO(logger_, "Got values " << values << " for channel " << channel);
+  //LOG4CXX_INFO(logger_, "Time frame: " << time_frame);
+  //LOG4CXX_INFO(logger_, "Events: " << num_events << ", Resets: " << num_resets << ", pad: " << num_padding);
+
+}
+
+}

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -22,6 +22,8 @@ X3X2ListModeProcessPlugin::X3X2ListModeProcessPlugin() :
   num_time_frames_(0),
   num_events_(),
   completed_channels_(),
+  prev_time_frames_(),
+  prev_time_stamps_(),
   acquisition_complete_(false)
 {
   // Setup logging for the class
@@ -307,11 +309,15 @@ void X3X2ListModeProcessPlugin::setup_channel_memory_blocks(uint32_t channel)
 void X3X2ListModeProcessPlugin::reset_channel_statistics()
 {
   completed_channels_.clear();
+  prev_time_frames_.clear();
+  prev_time_stamps_.clear();
   num_events_.clear();
   for (auto const& chan : channels_)
   {
     completed_channels_[chan] = false;
     num_events_[chan] = 0;
+    prev_time_frames_[chan] = 0;
+    prev_time_stamps_[chan] = 0;
   }
 }
 
@@ -358,10 +364,6 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
 
   uint16_t* frame_data = static_cast<uint16_t *>(frame->get_data_ptr());
 
-  // TODO: remove after testing
-  std::string ids("");
-  std::string values("");
-
   // Event attributes
   uint16_t acquisition_number = 0;
   uint64_t time_frame = 0;
@@ -392,10 +394,6 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
     id = frame_data[field] >> 12;
     value = frame_data[field] & 0xFFF;
     value_64 = (uint64_t) value;
-
-    // TODO: remove after testing
-    //ids += std::to_string(id) + ",";
-    //values += std::to_string(value) + ",";
 
     switch (id)
     {
@@ -453,14 +451,43 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         // Event height
         event_height = value;
 
-        // TODO: remove when tested
-        //LOG4CXX_INFO(logger_, "Got values: " << time_frame << ", " << time_stamp << ", " << event_height << " for first event ");
-        //return
+        // Check for time frame and time stamp decreasing
+        // this may be a sign that the receiver buffer
+        // is being overwritten before being processed
+        if (time_frame < prev_time_frames_[channel])
+        {
+          LOG4CXX_INFO(
+            logger_,
+            "Channel "
+            << channel
+            << " stepped back from "
+            << prev_time_frames_[channel]
+            << " to "
+            << time_frame
+            << " at field " << field
+          );
+        }
+        if (time_stamp < prev_time_stamps_[channel])
+        {
+          LOG4CXX_INFO(
+            logger_,
+            "Channel "
+            << channel
+            << " walked back timestamp at field "
+            << field
+            << " from "
+            << prev_time_stamps_[channel]
+            << " to "
+            << time_stamp
+          );
+        }
+        prev_time_frames_[channel] = time_frame;
+        prev_time_stamps_[channel] = time_stamp;
 
         // xspress3m_active_readout only counts events when not end of frame so we copy this logic here
         if (!end_of_frame)
         {
-          if (dummy_event == 0) {
+          if (!dummy_event) {
             boost::shared_ptr <Frame> frame;
 
             frame = (timeframe_memory_ptrs_[channel])->add_timeframe(time_frame);
@@ -488,7 +515,6 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         {
           // TODO: work out why we get more events after the end of frame marker is set and see if we need to
           // save them or ignore them (we ignore them here)
-          LOG4CXX_INFO(logger_, "Channel " << channel << " got end of frame for frame " << time_frame);
           if (time_frame + 1 == num_time_frames_)
           {
             LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames complete for channel " << channel);
@@ -516,11 +542,9 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
             }
           }
         }
-
         break;
     }
   }
-
 }
 
 }

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPlugin.cpp
@@ -1,9 +1,11 @@
 #include <iostream>
+
 #include "DataBlockFrame.h"
+#include "DebugLevelLogger.h"
+
 #include "X3X2ListModeProcessPlugin.h"
 #include "FrameProcessorDefinitions.h"
 #include "X3X2Definitions.h"
-#include "DebugLevelLogger.h"
 
 
 namespace FrameProcessor {
@@ -14,115 +16,13 @@ const std::string X3X2ListModeProcessPlugin::CONFIG_FLUSH_ACQUISITION =  "flush"
 const std::string X3X2ListModeProcessPlugin::CONFIG_FRAME_SIZE =         "frame_size";
 const std::string X3X2ListModeProcessPlugin::CONFIG_TIME_FRAMES =        "time_frames";
 
-X3X2ListModeMemoryBlock::X3X2ListModeMemoryBlock(const std::string& name) :
-  ptr_(0),
-  num_bytes_(0),
-  filled_size_(0),
-  frame_count_(0)
-{
-  // Setup logging for the class
-  logger_ = Logger::getLogger("FP.X3X2ListModeProcessPlugin");
-  LOG4CXX_INFO(logger_, "Created X3X2ListModeMemoryBlock");
-
-  name_ = name;
-}
-
-X3X2ListModeMemoryBlock::~X3X2ListModeMemoryBlock()
-{
-  if (ptr_){
-    free(ptr_);
-  }
-}
-
-void X3X2ListModeMemoryBlock::set_size(uint32_t bytes)
-{
-  // Round allocation down to number of whole events
-  num_bytes_ = (bytes/num_bytes_per_event_)*num_bytes_per_event_;
-  reallocate();
-}
-
-void X3X2ListModeMemoryBlock::reallocate()
-{
-  LOG4CXX_INFO(logger_, "Reallocating X3X2ListModeMemoryBlock to [" << num_bytes_ << "] bytes");
-  if (ptr_){
-    free(ptr_);
-  }
-  ptr_ = (char *)malloc(num_bytes_);
-  reset();
-}
-
-void X3X2ListModeMemoryBlock::reset()
-{
-  memset(ptr_, 0, num_bytes_);
-  filled_size_ = 0;
-}
-
-void X3X2ListModeMemoryBlock::reset_frame_count()
-{
-  frame_count_ = 0;
-}
-
-boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::add_event(uint64_t time_frame, uint64_t time_stamp, uint64_t event_height)
-{
-  boost::shared_ptr <Frame> frame;
-
-  // Calculate the current end of data pointer location
-  char *dest = (char *)ptr_;
-  dest += filled_size_;
-
-  // Add the event
-  // *(reinterpret_cast<uint64_t>(dest)) = event_height;
-  *((uint64_t *)dest) = time_frame;
-  *((uint64_t *)(dest) + 1) = time_stamp;
-  *((uint64_t *)(dest) + 2) = event_height;
-
-  filled_size_ += 3*sizeof(uint64_t);
-
-  // Final check, if we have a full buffer then send it out
-  if (filled_size_ == num_bytes_){
-    frame = this->to_frame();
-  }
-
-  return frame;
-}
-
-boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::to_frame()
-{
-  boost::shared_ptr <Frame> frame;
-
-  // Create the frame around the current (partial) block
-  dimensions_t dims;
-  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
-  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, num_bytes_));
-  memcpy(frame->get_data_ptr(), ptr_, num_bytes_);
-
-  // Reset the block
-  reset();
-
-  // Add 1 to the frame count
-  frame_count_++;
-
-  return frame;
-}
-
-boost::shared_ptr <Frame> X3X2ListModeMemoryBlock::flush()
-{
-  boost::shared_ptr <Frame> frame;
-
-  // Create the frame around the current (partial) block
-  dimensions_t dims;
-  FrameMetaData list_metadata(frame_count_, name_, raw_64bit, "", dims);
-  frame = boost::shared_ptr<Frame>(new DataBlockFrame(list_metadata, filled_size_));
-  memcpy(frame->get_data_ptr(), ptr_, filled_size_);
-
-  return frame;
-}
-
 X3X2ListModeProcessPlugin::X3X2ListModeProcessPlugin() :
   num_channels_(0),
   channel_offset_(0),
   num_time_frames_(0),
-  num_completed_channels_(0)
+  num_events_(),
+  completed_channels_(),
+  acquisition_complete_(false)
 {
   // Setup logging for the class
   logger_ = Logger::getLogger("FP.X3X2ListModeProcessPlugin");
@@ -205,65 +105,229 @@ void X3X2ListModeProcessPlugin::set_channels(std::vector<uint32_t> channels)
 {
   channels_ = channels;
   num_channels_ = channels.size();
+
+  reset_channel_statistics();
+
   // TCP frames only report as channels 0 and 1 - we need to store
   // the offset so we can report the correct system channels to the file
   // writer
   channel_offset_ = channels_[0];
+
   // We must reallocate memory blocks
   setup_memory_allocation();
+}
+
+void X3X2ListModeProcessPlugin::clear_timeframe_memory_blocks()
+{
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock> >::iterator iter;
+  for (iter = timeframe_memory_ptrs_.begin(); iter != timeframe_memory_ptrs_.end(); ++iter){
+    iter->second->reset_frame_count();
+    iter->second->reset();
+  }
+}
+
+void X3X2ListModeProcessPlugin::clear_timestamp_memory_blocks()
+{
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimestampMemoryBlock> >::iterator iter;
+  for (iter = timestamp_memory_ptrs_.begin(); iter != timestamp_memory_ptrs_.end(); ++iter){
+    iter->second->reset_frame_count();
+    iter->second->reset();
+  }
+}
+
+void X3X2ListModeProcessPlugin::clear_event_height_memory_blocks()
+{
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeEventHeightMemoryBlock> >::iterator iter;
+  for (iter = event_height_memory_ptrs_.begin(); iter != event_height_memory_ptrs_.end(); ++iter){
+    iter->second->reset_frame_count();
+    iter->second->reset();
+  }
+}
+
+void X3X2ListModeProcessPlugin::clear_reset_flag_memory_blocks()
+{
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeResetFlagMemoryBlock> >::iterator iter;
+  for (iter = reset_flag_memory_ptrs_.begin(); iter != reset_flag_memory_ptrs_.end(); ++iter){
+    iter->second->reset_frame_count();
+    iter->second->reset();
+  }
 }
 
 void X3X2ListModeProcessPlugin::reset_acquisition()
 {
   LOG4CXX_INFO(logger_, "Resetting acquisition");
-  std::map<uint32_t, boost::shared_ptr<X3X2ListModeMemoryBlock> >::iterator iter;
-  for (iter = memory_ptrs_.begin(); iter != memory_ptrs_.end(); ++iter){
-    iter->second->reset_frame_count();
-    iter->second->reset();
-  }
 
-  num_completed_channels_ = 0;
+  clear_timeframe_memory_blocks();
+  clear_timestamp_memory_blocks();
+  clear_event_height_memory_blocks();
+  clear_reset_flag_memory_blocks();
+
+  acquisition_complete_ = false;
+
+  reset_channel_statistics();
 }
 
-void X3X2ListModeProcessPlugin::flush_close_acquisition()
+void X3X2ListModeProcessPlugin::flush_timeframe_memory_blocks()
 {
-  LOG4CXX_INFO(logger_, "Flushing and closing acquisition");
-  std::map<uint32_t, boost::shared_ptr<X3X2ListModeMemoryBlock> >::iterator iter;
-  for (iter = memory_ptrs_.begin(); iter != memory_ptrs_.end(); ++iter){
-    LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing frame for channel " << iter->first);
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock> >::iterator iter;
+  for (iter = timeframe_memory_ptrs_.begin(); iter != timeframe_memory_ptrs_.end(); ++iter){
+    LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing timeframe for channel " << iter->first);
     boost::shared_ptr <Frame> list_frame = iter->second->to_frame();
     if (list_frame){
       this->push(list_frame);
     }
   }
+}
+
+void X3X2ListModeProcessPlugin::flush_timestamp_memory_blocks()
+{
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeTimestampMemoryBlock> >::iterator iter;
+  for (iter = timestamp_memory_ptrs_.begin(); iter != timestamp_memory_ptrs_.end(); ++iter){
+    LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing timestamp for channel " << iter->first);
+    boost::shared_ptr <Frame> list_frame = iter->second->to_frame();
+    if (list_frame){
+      this->push(list_frame);
+    }
+  }
+}
+
+void X3X2ListModeProcessPlugin::flush_event_height_memory_blocks()
+{
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeEventHeightMemoryBlock> >::iterator iter;
+  for (iter = event_height_memory_ptrs_.begin(); iter != event_height_memory_ptrs_.end(); ++iter){
+    LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing event height for channel " << iter->first);
+    boost::shared_ptr <Frame> list_frame = iter->second->to_frame();
+    if (list_frame){
+      this->push(list_frame);
+    }
+  }
+}
+
+void X3X2ListModeProcessPlugin::flush_reset_flag_memory_blocks()
+{
+  std::map<uint32_t, boost::shared_ptr<X3X2ListModeResetFlagMemoryBlock> >::iterator iter;
+  for (iter = reset_flag_memory_ptrs_.begin(); iter != reset_flag_memory_ptrs_.end(); ++iter){
+    LOG4CXX_DEBUG_LEVEL(0, logger_, "Flushing event height for channel " << iter->first);
+    boost::shared_ptr <Frame> list_frame = iter->second->to_frame();
+    if (list_frame){
+      this->push(list_frame);
+    }
+  }
+}
+
+void X3X2ListModeProcessPlugin::flush_close_acquisition()
+{
+  LOG4CXX_INFO(logger_, "Flushing and closing acquisition");
+
+  flush_timeframe_memory_blocks();
+  flush_timestamp_memory_blocks();
+  flush_event_height_memory_blocks();
+  flush_reset_flag_memory_blocks();
+
   this->notify_end_of_acquisition();
 }
 
-void X3X2ListModeProcessPlugin::set_frame_size(uint32_t num_bytes)
+/**
+ * Set the frame size in terms of number of events for each memory block
+ *
+ * This is different from Xspress 4 which uses bytes as we want a separate
+ * dataset for each event field here.
+ *
+ *  \param[in] num_events - number of events to store per frame
+ */
+void X3X2ListModeProcessPlugin::set_frame_size(uint32_t num_events)
 {
-  LOG4CXX_INFO(logger_, "Setting frame size to " << num_bytes << " bytes");
-  frame_size_bytes_ = num_bytes;
+  LOG4CXX_INFO(logger_, "Setting frame size to " << num_events << " events");
+  frame_size_events_ = num_events;
   // We must reallocate memory blocks
   setup_memory_allocation();
 }
 
+/**
+ * Set up the channel memory blocks for a single channel
+ *
+ * A separate block is used for each event field.
+ *
+ * \param[in] channel - Channel number
+ */
+void X3X2ListModeProcessPlugin::setup_channel_memory_blocks(uint32_t channel)
+{
+  // Names for memory block frames
+  std::string timeframe_name = "ch" + std::to_string(channel) + "_time_frame";
+  std::string timestamp_name = "ch" + std::to_string(channel) + "_time_stamp";
+  std::string event_height_name = "ch" + std::to_string(channel) + "_event_height";
+  std::string reset_flag_name = "ch" + std::to_string(channel) + "_reset_flag";
+
+  // Size of each memory block in bytes based on the number of events we want to
+  // store in each frame
+  uint32_t frame_size_tf_bytes = frame_size_events_ * sizeof(uint64_t);
+  uint32_t frame_size_ts_bytes = frame_size_events_ * sizeof(uint64_t);
+  uint32_t frame_size_eh_bytes = frame_size_events_ * sizeof(uint16_t);
+  uint32_t frame_size_rf_bytes = frame_size_events_ * sizeof(uint8_t);
+
+  // Create the memory blocks
+  boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock> frame_ptr =
+    boost::shared_ptr<X3X2ListModeTimeframeMemoryBlock>(
+      new X3X2ListModeTimeframeMemoryBlock(timeframe_name)
+    );
+  frame_ptr->set_size(frame_size_tf_bytes);
+  timeframe_memory_ptrs_[channel] = frame_ptr;
+
+  boost::shared_ptr<X3X2ListModeTimestampMemoryBlock> stamp_ptr =
+    boost::shared_ptr<X3X2ListModeTimestampMemoryBlock>(
+      new X3X2ListModeTimestampMemoryBlock(timestamp_name)
+    );
+  stamp_ptr->set_size(frame_size_ts_bytes);
+  timestamp_memory_ptrs_[channel] = stamp_ptr;
+
+  boost::shared_ptr<X3X2ListModeEventHeightMemoryBlock> height_ptr =
+    boost::shared_ptr<X3X2ListModeEventHeightMemoryBlock>(
+      new X3X2ListModeEventHeightMemoryBlock(event_height_name)
+    );
+  // TODO: testing smaller frame size in case it fixes missing events
+  height_ptr->set_size(frame_size_eh_bytes);
+  event_height_memory_ptrs_[channel] = height_ptr;
+
+  boost::shared_ptr<X3X2ListModeResetFlagMemoryBlock> reset_ptr =
+    boost::shared_ptr<X3X2ListModeResetFlagMemoryBlock>(
+      new X3X2ListModeResetFlagMemoryBlock(reset_flag_name)
+    );
+  // TODO: testing smaller frame size in case it fixes missing events
+  reset_ptr->set_size(frame_size_rf_bytes);
+  reset_flag_memory_ptrs_[channel] = reset_ptr;
+
+  // Setup the storage vectors for the packet header information
+  std::vector<uint32_t> hdr(3, 0);
+  packet_headers_[channel] = hdr;
+}
+
+/**
+ * Reset the attributes used to track attributes per channel
+ */
+void X3X2ListModeProcessPlugin::reset_channel_statistics()
+{
+  completed_channels_.clear();
+  num_events_.clear();
+  for (auto const& chan : channels_)
+  {
+    completed_channels_[chan] = false;
+    num_events_[chan] = 0;
+  }
+}
+
 void X3X2ListModeProcessPlugin::setup_memory_allocation()
 {
-  // First clear out the memory vector emptying any blocks
-  memory_ptrs_.clear();
+  // First clear out the memory vectors emptying any blocks
+  timeframe_memory_ptrs_.clear();
+  timestamp_memory_ptrs_.clear();
+  event_height_memory_ptrs_.clear();
+  reset_flag_memory_ptrs_.clear();
 
   // Allocate large enough blocks of memory to hold list mode frames
-  // Allocate one block of memory for each channel
+  // Allocate one block of memory for each event field for each channel
   std::vector<uint32_t>::iterator iter;
   for (iter = channels_.begin(); iter != channels_.end(); ++iter){
-    std::stringstream ss;
-    ss << "raw_" << *iter;
-    boost::shared_ptr<X3X2ListModeMemoryBlock> ptr = boost::shared_ptr<X3X2ListModeMemoryBlock>(new X3X2ListModeMemoryBlock(ss.str()));
-    ptr->set_size(frame_size_bytes_);
-    memory_ptrs_[*iter] = ptr;
-    // Setup the storage vectors for the packet header information
-    std::vector<uint32_t> hdr(3, 0);
-    packet_headers_[*iter] = hdr;
+    setup_channel_memory_blocks(*iter);
   }
 }
 
@@ -289,6 +353,9 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
 {
   // LOG4CXX_INFO(logger_, "Processing frame " << frame->get_frame_number() << " of size " << frame->get_data_size() << " at " << frame->get_data_ptr());
 
+  // Packet arrived after we got the EOF for the desired time frame
+  if (acquisition_complete_) return;
+
   uint16_t* frame_data = static_cast<uint16_t *>(frame->get_data_ptr());
 
   // TODO: remove after testing
@@ -300,17 +367,18 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
   uint64_t time_frame = 0;
   uint64_t time_stamp = 0;
 
-  uint64_t event_height = 0;
+  uint16_t event_height = 0;
 
   bool dummy_event = 0;
   bool end_of_frame = 0;
   bool ttl_a = 0;
   bool ttl_b = 0;
 
+  bool reset_flag = false;
+
   uint16_t channel = -1;
 
   // Track number of events
-  unsigned int num_events = 0;
   unsigned int num_resets = 0;
   unsigned int num_padding = 0;
 
@@ -339,7 +407,7 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
         ttl_a = value & 0x2;
         ttl_b = value & 0x4;
         dummy_event = value & 0x8;
-        time_frame = (time_frame & 0xFFFFFFFFFFFFFF00) | (value_64 >> 4);
+        time_frame = (time_frame & 0xFFFFFFFFFFFFFF00) | ((value_64 & 0xFF0) >> 4);
         break;
       case 5:
         time_frame = (time_frame & 0xFFFFFFFFFFF000FF) | (value_64 << 8);
@@ -356,11 +424,12 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
       case 9:
         // Calculate actual channel in system
         channel = (value >> 8) + channel_offset_;
-        // Check we have the right channel (and ignore markers)
-        if (memory_ptrs_.find(channel) == memory_ptrs_.end()) {
+        // Check we have the right channel (and ignore marker channels for now)
+        if (std::find(channels_.begin(), channels_.end(), channel) == channels_.end()) {
+          // Ignore entire packet
           return;
         }
-        time_frame = (time_frame & 0x00FFFFFFFFFFFFFF) | (value_64 << 56);
+        time_frame = (time_frame & 0x00FFFFFFFFFFFFFF) | ((value_64 & 0xFF) << 56);
         break;
       case 10:
         time_stamp = (time_stamp & 0xFFFFFFFFF000) | value_64;
@@ -380,58 +449,77 @@ void X3X2ListModeProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
       case 14:
         // Reset event width
         num_resets++;
-        if (end_of_frame)
-        {
-          LOG4CXX_INFO(logger_, "Channel " << channel << " got end of frame for frame " << time_frame <<  " need: " << num_time_frames_);
-          if (time_frame + 1 == num_time_frames_)
-          {
-            LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames complete for channel " << channel);
-            num_completed_channels_++;
-          }
-        }
-        break;
       case 0:
         // Event height
         event_height = value;
-
-        // TODO: account for dummy events
 
         // TODO: remove when tested
         //LOG4CXX_INFO(logger_, "Got values: " << time_frame << ", " << time_stamp << ", " << event_height << " for first event ");
         //return
 
-        // Add event
-        boost::shared_ptr <Frame> list_frame = (memory_ptrs_[channel])->add_event(time_frame, time_stamp, event_height);
-        if (list_frame){
-          // LOG4CXX_DEBUG_LEVEL(1, logger_, "Completed frame for channel " << channel << ", pushing");
-          // There is a full frame available for pushing
-          this->push(list_frame);
-        }
-        if (end_of_frame)
+        // xspress3m_active_readout only counts events when not end of frame so we copy this logic here
+        if (!end_of_frame)
         {
+          if (dummy_event == 0) {
+            boost::shared_ptr <Frame> frame;
+
+            frame = (timeframe_memory_ptrs_[channel])->add_timeframe(time_frame);
+            // Memory block frame completed
+            if (frame) this->push(frame);
+
+            frame = (timestamp_memory_ptrs_[channel])->add_timestamp(time_stamp);
+            // Memory block frame completed
+            if (frame) this->push(frame);
+
+            frame = (event_height_memory_ptrs_[channel])->add_event_height(event_height);
+            // Memory block frame completed
+            if (frame) this->push(frame);
+
+            reset_flag = (id == 14) ? true : false;
+            frame = (reset_flag_memory_ptrs_[channel])->add_reset_flag(reset_flag);
+            // Memory block frame completed
+            if (frame) this->push(frame);
+
+            // Track overall number of recorded events in acquisition (including resets)
+            num_events_[channel]++;
+          }
+        }
+        else if (!acquisition_complete_)
+        {
+          // TODO: work out why we get more events after the end of frame marker is set and see if we need to
+          // save them or ignore them (we ignore them here)
           LOG4CXX_INFO(logger_, "Channel " << channel << " got end of frame for frame " << time_frame);
           if (time_frame + 1 == num_time_frames_)
           {
             LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames complete for channel " << channel);
-            num_completed_channels_++;
+            completed_channels_[channel] = true;
+
+            // Check if every channel is now finished
+            uint16_t completed_channels = 0;
+            for (auto const& it : completed_channels_)
+            {
+              if (it.second) completed_channels++;
+            }
+            if (completed_channels == num_channels_)
+            {
+              this->flush_close_acquisition();
+              acquisition_complete_ = true;
+              LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames completed for all channels");
+              for (auto const& chan : channels_)
+              {
+                LOG4CXX_INFO(
+                  logger_,
+                  "Total events in channel " << chan << ": " << num_events_[chan]
+                );
+              }
+              return;
+            }
           }
         }
-        num_events++;
+
         break;
     }
   }
-
-  if (num_completed_channels_ == num_channels_)
-  {
-    LOG4CXX_INFO(logger_, "Acquisition of " << num_time_frames_ << " frames completed for all channels");
-    this->flush_close_acquisition();
-  }
-
-  // TODO: remove after testing
-  //LOG4CXX_INFO(logger_, "Got ids " << ids << " for channel " << channel);
-  //LOG4CXX_INFO(logger_, "Got values " << values << " for channel " << channel);
-  //LOG4CXX_INFO(logger_, "Time frame: " << time_frame);
-  //LOG4CXX_INFO(logger_, "Events: " << num_events << ", Resets: " << num_resets << ", pad: " << num_padding);
 
 }
 

--- a/cpp/data/frameProcessor/src/X3X2ListModeProcessPluginLib.cpp
+++ b/cpp/data/frameProcessor/src/X3X2ListModeProcessPluginLib.cpp
@@ -1,0 +1,13 @@
+#include "X3X2ListModeProcessPlugin.h"
+#include "ClassLoader.h"
+
+namespace FrameProcessor
+{
+    /**
+     * Registration of this process plugin through the ClassLoader.  This macro
+     * registers the class without needing to worry about name mangling
+     */
+    REGISTER(FrameProcessorPlugin, X3X2ListModeProcessPlugin, "X3X2ListModeProcessPlugin");
+
+} // namespace FrameReceiver
+

--- a/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
+++ b/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
@@ -1,0 +1,75 @@
+/**
+ * @file X3X2ListModeFrameDecoder.h
+ * @author Ben Bradnick (ben@quantumdetectors.com)
+ * @brief Odin receiver plugin for handling X3X2 list mode TCP data
+ * @date 2024-11-06
+ */
+
+#ifndef INCLUDE_X3X2LISTMODEFRAMEDECODER_H_
+#define INCLUDE_X3X2LISTMODEFRAMEDECODER_H_
+
+#include <iostream>
+#include <stdint.h>
+#include <time.h>
+
+#include "FrameDecoderTCP.h"
+
+namespace FrameReceiver {
+
+namespace X3X2ListModeFrameDecoderDefaults {
+  const int frame_number = -1;
+  const int buffer_id = 0;
+  const size_t max_size = 8192; // Each TCP frame is 8192 bytes of 4096 16 bit words
+  const size_t header_size = 30; // Header is first and should contain 15 words
+  const int num_buffers = 5;
+} // namespace X3X2ListModeFrameDecoderDefaults
+
+class X3X2ListModeFrameDecoder : public FrameDecoderTCP {
+public:
+  X3X2ListModeFrameDecoder();
+  ~X3X2ListModeFrameDecoder();
+
+  int get_version_major();
+  int get_version_minor();
+  int get_version_patch();
+  std::string get_version_short();
+  std::string get_version_long();
+
+  void monitor_buffers(void);
+  void get_status(const std::string param_prefix,
+                  OdinData::IpcMessage &status_msg);
+
+  void init(LoggerPtr &logger, OdinData::IpcMessage &config_msg);
+  void request_configuration(const std::string param_prefix,
+                             OdinData::IpcMessage &config_reply);
+
+  void *get_next_message_buffer(void);
+  const size_t get_next_message_size(void) const;
+  FrameDecoder::FrameReceiveState process_message(size_t bytes_received);
+
+  const size_t get_frame_buffer_size(void) const;
+  const size_t get_frame_header_size(void) const;
+
+  void reset_statistics(void);
+
+  void *get_packet_header_buffer(void);
+
+  uint32_t get_frame_number(void) const;
+  uint32_t get_packet_number(void) const;
+
+private:
+  boost::shared_ptr<void> frame_buffer_;
+  size_t frames_dropped_;
+  size_t frames_sent_;
+  size_t read_so_far_;
+  int current_frame_number_;
+  int current_frame_buffer_id_;
+  size_t buffer_size_;
+  size_t header_size_;
+  size_t frame_size_;
+  unsigned int num_buffers_;
+  FrameDecoder::FrameReceiveState receive_state_;
+};
+
+} // namespace FrameReceiver
+#endif /* INCLUDE_X3X2LISTMODEFRAMEDECODER_H_ */

--- a/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
+++ b/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
@@ -23,7 +23,7 @@ namespace X3X2ListModeFrameDecoderDefaults {
   const int buffer_id = 0;
   const size_t max_size = X3X2_MINI_TCP_FRAME_SIZE; // Each TCP frame is 8192 bytes of 4096 16 bit words
   const size_t header_size = 0; // Initially we do not need a header
-  const int num_buffers = 5;
+  const int num_buffers = 12800; // 100MB buffer
 } // namespace X3X2ListModeFrameDecoderDefaults
 
 class X3X2ListModeFrameDecoder : public FrameDecoderTCP {

--- a/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
+++ b/cpp/data/frameReceiver/include/X3X2ListModeFrameDecoder.h
@@ -14,13 +14,15 @@
 
 #include "FrameDecoderTCP.h"
 
+#include "X3X2Definitions.h"
+
 namespace FrameReceiver {
 
 namespace X3X2ListModeFrameDecoderDefaults {
-  const int frame_number = -1;
+  const int frame_number = 0;
   const int buffer_id = 0;
-  const size_t max_size = 8192; // Each TCP frame is 8192 bytes of 4096 16 bit words
-  const size_t header_size = 30; // Header is first and should contain 15 words
+  const size_t max_size = X3X2_MINI_TCP_FRAME_SIZE; // Each TCP frame is 8192 bytes of 4096 16 bit words
+  const size_t header_size = 0; // Initially we do not need a header
   const int num_buffers = 5;
 } // namespace X3X2ListModeFrameDecoderDefaults
 

--- a/cpp/data/frameReceiver/include/XspressListModeFrameDecoder.h
+++ b/cpp/data/frameReceiver/include/XspressListModeFrameDecoder.h
@@ -1,3 +1,10 @@
+/**
+ * @file XspressListModeFrameDecoder.h
+ * @author Alan Greer
+ * @brief This decoder is used to handle list mode events for Xspress 4
+ * @date 2025-01-02
+ */
+
 #ifndef SRC_XSPRESSLISTMODEDECODER_H
 #define SRC_XSPRESSLISTMODEDECODER_H
 

--- a/cpp/data/frameReceiver/src/CMakeLists.txt
+++ b/cpp/data/frameReceiver/src/CMakeLists.txt
@@ -10,6 +10,10 @@ target_link_libraries(XspressFrameDecoder ${ODINDATA_LIBRARIES} ${Boost_LIBRARIE
 add_library(XspressListModeFrameDecoder SHARED XspressListModeFrameDecoder.cpp XspressListModeFrameDecoderLib.cpp)
 target_link_libraries(XspressListModeFrameDecoder ${ODINDATA_LIBRARIES} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
 
+# Add library for xspress X3X2 list mode decoder
+add_library(X3X2ListModeFrameDecoder SHARED X3X2ListModeFrameDecoder.cpp X3X2ListModeFrameDecoderLib.cpp)
+target_link_libraries(X3X2ListModeFrameDecoder ${ODINDATA_LIBRARIES} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
+
 
 install(TARGETS XspressFrameDecoder
         RUNTIME DESTINATION bin
@@ -21,3 +25,7 @@ install(TARGETS XspressListModeFrameDecoder
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 
+install(TARGETS X3X2ListModeFrameDecoder
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)

--- a/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
+++ b/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
@@ -1,0 +1,168 @@
+/**
+ * @file X3X2ListModeFrameDecoder.cpp
+ * @author Ben Bradnick (ben@quantumdetectors.com)
+ * @brief Odin receiver plugin for handling X3X2 list mode TCP data
+ * @date 2024-11-06
+ */
+
+
+#include "X3X2ListModeFrameDecoder.h"
+#include "gettime.h"
+#include "version.h"
+#include <algorithm>
+#include <bitset>
+#include <boost/algorithm/string.hpp>
+#include <sstream>
+#include <string.h>
+#include <unistd.h>
+
+using namespace FrameReceiver;
+
+X3X2ListModeFrameDecoder::X3X2ListModeFrameDecoder()
+    : FrameDecoderTCP(),
+      current_frame_number_(X3X2ListModeFrameDecoderDefaults::frame_number),
+      current_frame_buffer_id_(X3X2ListModeFrameDecoderDefaults::buffer_id),
+      header_size_(X3X2ListModeFrameDecoderDefaults::header_size),
+      frame_size_(X3X2ListModeFrameDecoderDefaults::max_size),
+      num_buffers_(X3X2ListModeFrameDecoderDefaults::num_buffers),
+      frames_dropped_(0), frames_sent_(0), read_so_far_(0),
+      receive_state_(FrameDecoder::FrameReceiveStateEmpty) {
+  this->logger_ = Logger::getLogger("FR.X3X2ListModeFrameDecoder");
+  LOG4CXX_INFO(logger_, "X3X2ListModeFrameDecoder version "
+                            << this->get_version_long() << " loaded");
+  // buffer can fit 5 frames by default
+  buffer_size_ = num_buffers_ * frame_size_;
+  frame_buffer_.reset(new char[buffer_size_]);
+}
+
+//! Destructor for X3X2ListModeFrameDecoder
+X3X2ListModeFrameDecoder::~X3X2ListModeFrameDecoder() {}
+
+/**
+ * Initialises the frame decoder
+ *
+ * \param[in] logger The logger
+ * \param[in] config_msg The config parameters to initialise with
+ */
+void X3X2ListModeFrameDecoder::init(LoggerPtr &logger,
+                                OdinData::IpcMessage &config_msg) {}
+
+void X3X2ListModeFrameDecoder::reset_statistics() {
+  FrameDecoderTCP::reset_statistics();
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "X3X2ListModeFrameDecoder resetting statistics");
+  current_frame_number_ = X3X2ListModeFrameDecoderDefaults::frame_number;
+  current_frame_buffer_id_ = X3X2ListModeFrameDecoderDefaults::buffer_id;
+  frames_sent_ = 0;
+  read_so_far_ = 0;
+}
+
+//! Handle a request for the current decoder configuration.
+//!
+//! This method handles a request for the current decoder configuration, by
+//! populating an IPCMessage with all current configuration parameters.
+//!
+//! \param[in] param_prefix: string prefix to add to each parameter populated in
+//! reply \param[in,out] config_reply: IpcMessage to populate with current
+//! decoder parameters
+//!
+
+void X3X2ListModeFrameDecoder::request_configuration(
+    const std::string param_prefix, OdinData::IpcMessage &config_reply) {
+  // Call the base class method to populate parameters
+  FrameDecoder::request_configuration(param_prefix, config_reply);
+  config_reply.set_param(param_prefix + "frame_size", frame_size_);
+}
+
+/**
+ * Gets the buffer to use to store the next message, allocating one if necessary
+ *
+ * \return Pointer to the current buffer
+ */
+void *X3X2ListModeFrameDecoder::get_next_message_buffer(void) {
+  // only increment buffer when frame is complete
+  if (receive_state_ != FrameDecoder::FrameReceiveStateIncomplete) {
+    // get id in buffer circularly
+    if (current_frame_buffer_id_ + 1 >= num_buffers_)
+      current_frame_buffer_id_ = 0;
+    else
+      current_frame_buffer_id_++;
+  }
+  current_raw_buffer_ =
+      buffer_manager_->get_buffer_address(current_frame_buffer_id_);
+  return static_cast<void *>(static_cast<char *>(current_raw_buffer_) +
+                             read_so_far_);
+}
+
+//! Get the size of the frame buffers required for current operation mode.
+//!
+//! This method returns the frame buffer size required for the current operation
+//! mode.
+//!
+//! \return size of frame buffer in bytes
+//!
+const size_t X3X2ListModeFrameDecoder::get_frame_buffer_size(void) const {
+  return buffer_size_;
+}
+
+//! Get the size of the frame header.
+//!
+//! This method returns the size of the frame header used by the decoder.
+//!
+//! \return size of the frame header in bytes
+const size_t X3X2ListModeFrameDecoder::get_frame_header_size(void) const {
+  return header_size_;
+}
+
+/**
+ * Processes the message in the current buffer
+ *
+ * \param[in] bytes_received The number of bytes received
+ * \return The state after processing
+ */
+FrameDecoder::FrameReceiveState
+X3X2ListModeFrameDecoder::process_message(size_t bytes_received) {
+  LOG4CXX_INFO(logger_, "Processing " << bytes_received << " bytes");
+  if (read_so_far_ + bytes_received == frame_size_) {
+    read_so_far_ = 0;
+    return FrameDecoder::FrameReceiveStateComplete;
+  } else if (read_so_far_ + bytes_received < frame_size_) {
+    read_so_far_ += bytes_received;
+    // track how many bytes have been received out of the
+    // required total and attempt to complete by yielding control back to Rx
+    // thread.
+    return FrameDecoder::FrameReceiveStateIncomplete;
+  } else
+    throw "Not Implemented: Can not handle case when too many bytes received";
+}
+
+const size_t X3X2ListModeFrameDecoder::get_next_message_size(void) const {
+  return frame_size_ - read_so_far_;
+}
+
+void X3X2ListModeFrameDecoder::monitor_buffers(void) {}
+
+void X3X2ListModeFrameDecoder::get_status(const std::string param_prefix,
+                                      OdinData::IpcMessage &status_msg) {
+  status_msg.set_param(param_prefix + "name",
+                       std::string("X3X2ListModeFrameDecoder"));
+}
+
+int X3X2ListModeFrameDecoder::get_version_major() {
+  return XSPRESS_DETECTOR_VERSION_MAJOR;
+}
+
+int X3X2ListModeFrameDecoder::get_version_minor() {
+  return XSPRESS_DETECTOR_VERSION_MINOR;
+}
+
+int X3X2ListModeFrameDecoder::get_version_patch() {
+  return XSPRESS_DETECTOR_VERSION_PATCH;
+}
+
+std::string X3X2ListModeFrameDecoder::get_version_short() {
+  return XSPRESS_DETECTOR_VERSION_STR_SHORT;
+}
+
+std::string X3X2ListModeFrameDecoder::get_version_long() {
+  return XSPRESS_DETECTOR_VERSION_STR;
+}

--- a/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
+++ b/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoder.cpp
@@ -82,11 +82,9 @@ void X3X2ListModeFrameDecoder::request_configuration(
 void *X3X2ListModeFrameDecoder::get_next_message_buffer(void) {
   // only increment buffer when frame is complete
   if (receive_state_ != FrameDecoder::FrameReceiveStateIncomplete) {
-    // get id in buffer circularly
-    if (current_frame_buffer_id_ + 1 >= num_buffers_)
-      current_frame_buffer_id_ = 0;
-    else
-      current_frame_buffer_id_++;
+    // Get the buffer ID from the circular buffer
+    if (current_frame_buffer_id_ + 1 >= num_buffers_) current_frame_buffer_id_ = 0;
+    else current_frame_buffer_id_++;
 
     // Update position to new frame in frame buffer
     current_raw_buffer_ = buffer_manager_->get_buffer_address(current_frame_buffer_id_);
@@ -130,9 +128,8 @@ X3X2ListModeFrameDecoder::process_message(size_t bytes_received) {
   // LOG4CXX_INFO(logger_, "Processing " << bytes_received << " bytes");
   if (read_so_far_ + bytes_received == frame_size_) {
     read_so_far_ = 0;
-    // For now just send a single TCP frame
-    // LOG4CXX_INFO(logger_, "Completed TCP frame: " << current_frame_number_ << " in buffer " << current_frame_buffer_id_);
 
+    // Just send a single TCP frame
     ready_callback_(current_frame_buffer_id_, current_frame_number_);
 
     // Increment frame number
@@ -156,8 +153,8 @@ X3X2ListModeFrameDecoder::process_message(size_t bytes_received) {
 /**
  * Get the size of the next message to receiver over the TCP socket
  *
- * X3X2 uses fixed 8192 byte TCP frames and pads as necessary so wait
- * for this.
+ * X3X2 uses fixed 8192 byte TCP frames and pads as necessary for
+ * sparse events
  *
  * \return The size of the next TCP message
  */

--- a/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoderLib.cpp
+++ b/cpp/data/frameReceiver/src/X3X2ListModeFrameDecoderLib.cpp
@@ -1,0 +1,19 @@
+/**
+ * @file X3X2ListModeFrameDecoderLib.cpp
+ * @author Ben Bradnick (ben@quantumdetectors.com)
+ * @brief Registrar for X3X2 list mode receiver plugin
+ * @date 2024-11-06
+ */
+
+#include "X3X2ListModeFrameDecoder.h"
+#include "ClassLoader.h"
+
+namespace FrameReceiver
+{
+  /**
+   * Registration of this decoder through the ClassLoader.  This macro
+   * registers the class without needing to worry about name mangling
+   */
+  REGISTER(FrameDecoder, X3X2ListModeFrameDecoder, "X3X2ListModeFrameDecoder");
+}
+// namespace FrameReceiver

--- a/python/src/xspress_detector/control/adapter.py
+++ b/python/src/xspress_detector/control/adapter.py
@@ -90,7 +90,6 @@ class XspressAdapter(AsyncApiAdapter):
             if not isinstance(response, dict):
                 response = {"value": response}
 
-            response = "{}".format(response)
             status_code = 200
         except LookupError as e:
             response = {'invalid path': str(e)}

--- a/python/src/xspress_detector/control/adapter.py
+++ b/python/src/xspress_detector/control/adapter.py
@@ -40,7 +40,9 @@ class XspressAdapter(AsyncApiAdapter):
             endpoint = self.options['endpoint']
             ip, port = endpoint.split(":")
             num_process = int(self.options["num_process"])
-            num_process_list = max(2,num_process-1) if num_process >=2 else 1
+            # For X3X2 the number of list mode processes is the same as in MCA mode
+            # TODO: handle with a config flag so we don't break compatibility with Xspress 4
+            num_process_list = num_process
             self.detector = XspressDetector(ip, port, num_process_mca=num_process, num_process_list=num_process_list)
             logging.info(f"instatiated XspressDetector with ip = {ip} and port {port}\n num_process/list = {num_process}/{num_process_list}")
 

--- a/python/src/xspress_detector/control/adapter.py
+++ b/python/src/xspress_detector/control/adapter.py
@@ -90,7 +90,7 @@ class XspressAdapter(AsyncApiAdapter):
             if not isinstance(response, dict):
                 response = {"value": response}
 
-            respose = "{}".format(response)
+            response = "{}".format(response)
             status_code = 200
         except LookupError as e:
             response = {'invalid path': str(e)}

--- a/python/src/xspress_detector/control/client.py
+++ b/python/src/xspress_detector/control/client.py
@@ -7,7 +7,7 @@ import asyncio
 from odin_data.control.ipc_message import IpcMessage
 from zmq.eventloop.zmqstream import ZMQStream
 from zmq.utils.monitor import parse_monitor_message
-from zmq.utils.strtypes import unicode, cast_bytes, cast_unicode
+from zmq.utils.strtypes import cast_bytes, cast_unicode
 
 
 DEFAULT_TIMEOUT = 5

--- a/python/src/xspress_detector/control/fp_xspress_adapter.py
+++ b/python/src/xspress_detector/control/fp_xspress_adapter.py
@@ -111,7 +111,8 @@ class FPXspressAdapter(FrameProcessorAdapter):
                         # The file path is the same for all clients
                         parameters = {
                             'hdf': {
-                                'frames': self._param['config/hdf/frames']
+                                # Zero for X3X2 list mode as processor ends acquisition
+                                'frames': 0
                             }
                         }
                         # Send the number of frames first
@@ -169,7 +170,10 @@ class FPXspressAdapter(FrameProcessorAdapter):
                         "acq_id": self._param["config/hdf/acquisition_id"],
                         "chunks": int(self._batch_size),
                     },
-                    "xspress-list": {"reset": True},
+                    "xspress-list": {
+                        "reset": True,
+                        "time_frames": self._param["config/hdf/frames"],
+                    },
                 }
                 logging.warning("Sending: {}".format(parameters))
                 client.send_configuration(parameters)

--- a/python/src/xspress_detector/control/fp_xspress_adapter.py
+++ b/python/src/xspress_detector/control/fp_xspress_adapter.py
@@ -3,11 +3,8 @@ Created on March 2022
 
 :author: Alan Greer
 """
-import json
 import logging
 import os
-import asyncio
-import time
 
 from odin_data.control.odin_data_adapter import OdinDataAdapter
 from odin_data.control.frame_processor_adapter import FrameProcessorAdapter
@@ -17,7 +14,7 @@ from odin.adapters.adapter import (
     response_types,
 )
 from tornado import escape
-from tornado.escape import json_encode, json_decode
+from tornado.escape import json_decode
 
 
 def bool_from_string(value):

--- a/python/src/xspress_detector/control/fp_xspress_adapter.py
+++ b/python/src/xspress_detector/control/fp_xspress_adapter.py
@@ -10,7 +10,7 @@ import asyncio
 import time
 
 from odin_data.control.odin_data_adapter import OdinDataAdapter
-from odin_data.control.fp_compression_adapter import FPCompressionAdapter
+from odin_data.control.frame_processor_adapter import FrameProcessorAdapter
 from odin.adapters.adapter import (
     ApiAdapterResponse,
     request_types,
@@ -27,7 +27,7 @@ def bool_from_string(value):
     return bool_value
 
 
-class FPXspressAdapter(FPCompressionAdapter):
+class FPXspressAdapter(FrameProcessorAdapter):
     """
     FPXspressAdapter class
 
@@ -189,4 +189,4 @@ class FPXspressAdapter(FPCompressionAdapter):
                     "config/hdf/dataset/data",
                     "config/hdf/dataset/{}".format(dataset) + "/{}".format(client),
                 )
-                super(FPCompressionAdapter.__base__, self).put(dataset_path, request)
+                super(FrameProcessorAdapter.__base__, self).put(dataset_path, request)

--- a/python/src/xspress_detector/control/live_view_merge.py
+++ b/python/src/xspress_detector/control/live_view_merge.py
@@ -1,12 +1,7 @@
 import zmq
-import struct
-import numpy as np
 import json
 import argparse
-from datetime import datetime
 import logging
-
-
 
 
 class LiveViewCombiner(object):


### PR DESCRIPTION
marker channel setup now works for the ODIN xspress-detector if the configuration files set up the data.
Requires pyxspress > 0.7.1