### PR TITLE
Feature/tcp relay

### DIFF
--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -13,7 +13,9 @@ Added:
   odin_server.cfg to support using the TCP relay server to get list mode data.
   If set to 1, then the frame receivers will be told to connect to the TCP
   relay server. If set to 0 or not present then they will connect directly to
-  the Xspress system ports as before.
+  the Xspress system ports as before. The TCP relay server should be running
+  on the same system starting from port 13001 for the first card's connection,
+  incrementing by one for each card.
 
 
 0.5.0+qd0.6

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,10 +3,24 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
-0.5.0+qd0.6
------------ 
+
+0.5.0+qd0.7
+-----------
 
 Added:
+
+- Added optional config option `list_mode_tcp_relay` to the Xspress adapter in
+  odin_server.cfg to support using the TCP relay server to get list mode data.
+  If set to 1, then the frame receivers will be told to connect to the TCP
+  relay server. If set to 0 or not present then they will connect directly to
+  the Xspress system ports as before.
+
+
+0.5.0+qd0.6
+-----------
+
+Added:
+
 - Muxing for the TTL inputs which with the 0.7.1 pyxspress release of configuration files
   allows TTL in 0 and TTL in 1 to be recorded in the dataset.
 

--- a/python/src/xspress_detector/control/adapter.py
+++ b/python/src/xspress_detector/control/adapter.py
@@ -47,7 +47,7 @@ class XspressAdapter(AsyncApiAdapter):
             # Whether we are using the TCP relay server to fan out the X3X2 list mode
             # traffic
             if "list_mode_tcp_relay" in self.options:
-                use_tcp_relay_server = bool(self.options["list_mode_tcp_relay"])
+                use_tcp_relay_server = bool(int(self.options["list_mode_tcp_relay"]))
             else:
                 use_tcp_relay_server = False
 
@@ -58,7 +58,11 @@ class XspressAdapter(AsyncApiAdapter):
                 num_process_list=num_process_list,
                 use_tcp_relay_server=use_tcp_relay_server
             )
-            logging.info(f"instatiated XspressDetector with ip = {ip} and port {port}\n num_process/list = {num_process}/{num_process_list}")
+            logging.info(
+                f"instatiated XspressDetector with ip = {ip} and port {port}\n "
+                f"num_process/list = {num_process}/{num_process_list}\n "
+                f"TCP relay server: {use_tcp_relay_server}"
+            )
 
             num_cards = int(self.options['num_cards'])
             num_tf = int(self.options["num_tf"])

--- a/python/src/xspress_detector/control/adapter.py
+++ b/python/src/xspress_detector/control/adapter.py
@@ -43,7 +43,21 @@ class XspressAdapter(AsyncApiAdapter):
             # For X3X2 the number of list mode processes is the same as in MCA mode
             # TODO: handle with a config flag so we don't break compatibility with Xspress 4
             num_process_list = num_process
-            self.detector = XspressDetector(ip, port, num_process_mca=num_process, num_process_list=num_process_list)
+
+            # Whether we are using the TCP relay server to fan out the X3X2 list mode
+            # traffic
+            if "list_mode_tcp_relay" in self.options:
+                use_tcp_relay_server = bool(self.options["list_mode_tcp_relay"])
+            else:
+                use_tcp_relay_server = False
+
+            self.detector = XspressDetector(
+                ip,
+                port,
+                num_process_mca=num_process,
+                num_process_list=num_process_list,
+                use_tcp_relay_server=use_tcp_relay_server
+            )
             logging.info(f"instatiated XspressDetector with ip = {ip} and port {port}\n num_process/list = {num_process}/{num_process_list}")
 
             num_cards = int(self.options['num_cards'])

--- a/python/src/xspress_detector/control/detector.py
+++ b/python/src/xspress_detector/control/detector.py
@@ -16,6 +16,8 @@ from typing import Any
 from odin.adapters.adapter import ApiAdapterRequest, ApiAdapter
 from odin_data.control.ipc_message import IpcMessage
 
+from xspress_detector.control.util import get_x3x2_list_mode_addresses
+
 from .client import AsyncClient
 from .debug import debug_method
 from .parameter_tree import (
@@ -322,6 +324,7 @@ class XspressDetector(object):
         debug_level=logging.INFO,
         num_process_mca=NUM_FR_MCA,
         num_process_list=NUM_FR_LIST,
+        use_tcp_relay_server=False,
     ):
         self.logger = logging.getLogger()
         self.logger.setLevel(debug_level)
@@ -338,6 +341,10 @@ class XspressDetector(object):
         # process params
         self.num_process_list = num_process_list
         self.num_process_mca = num_process_mca
+
+        # Whether we are using a TCP relay server to fan out the Xspress TCP
+        # data when in list mode
+        self.use_tcp_relay_server = use_tcp_relay_server
 
         # root level parameter tree members
         self.ctr_endpoint = ENDPOINT_TEMPLATE.format(ip, port)
@@ -856,7 +863,7 @@ class XspressDetector(object):
             #  - IP addresses and ports
             #  - decoder plugin to use
             # One ADC card per process pair (one TCP connection each)
-            ip_and_ports = [(f"192.168.0.{card_num+1}", [30125]) for card_num in range(1, self.num_cards+1)]
+            ip_and_ports = get_x3x2_list_mode_addresses(self.num_cards, self.use_tcp_relay_server)
             self.logger.info(f"Connecting to list mode sockets {ip_and_ports}")
             configs = [
                 {

--- a/python/src/xspress_detector/control/util.py
+++ b/python/src/xspress_detector/control/util.py
@@ -1,3 +1,4 @@
+from typing import Tuple, List
 
 class ListModeIPPortGen:
     IP_PREFIX = "192.168.0."
@@ -44,3 +45,22 @@ class ListModeIPPortGen:
             self.ip_last += self.IP_STEP
         self.current_count =  self.current_count % self.NUM_PORTS_PER_IP
         return ip, ports
+
+def get_x3x2_list_mode_addresses(num_cards: int, use_tcp_relay: bool) -> List[Tuple[str, List[int]]]:
+    """Get the list of addresses for the frame receivers to connect to for X3X2 list mode
+
+    This will return the addresses of the Xspress cards if connecting directly or the
+    addresses of the TCP relay server applications (1 per card).
+
+    Args:
+        num_cards (int): Number of cards in the Xspress system
+        use_tcp_relay (bool): False to connect directly to Xspress or True
+                              to connect to the TCP relay application
+
+    Returns:
+        List[Tuple[str, List[int]]]: List of addresses as [(ip, [port]),...]
+    """
+    if not use_tcp_relay:
+        return [(f"192.168.0.{card_num+1}", [30125]) for card_num in range(1, num_cards+1)]
+    else:
+        return [("127.0.0.1", [13001 + card_num]) for card_num in range(1, num_cards+1)]

--- a/python/src/xspress_detector/control/util.py
+++ b/python/src/xspress_detector/control/util.py
@@ -63,4 +63,4 @@ def get_x3x2_list_mode_addresses(num_cards: int, use_tcp_relay: bool) -> List[Tu
     if not use_tcp_relay:
         return [(f"192.168.0.{card_num+1}", [30125]) for card_num in range(1, num_cards+1)]
     else:
-        return [("127.0.0.1", [13001 + card_num]) for card_num in range(1, num_cards+1)]
+        return [("127.0.0.1", [13000 + card_num]) for card_num in range(1, num_cards+1)]


### PR DESCRIPTION
This adds an optional config option `list_mode_tcp_relay` to the Xspress adapter in  odin_server.cfg to support using the TCP relay server to get list mode data.

If this option is set to 1, then the frame receivers will be told to connect to the TCP  relay server. If set to 0 or not present then they will connect directly to  the Xspress system ports, as before.

The TCP relay server should be running on the same system starting from port 13001 for the first card's connection (adding one each time).