### PR TITLE
Feature/list mode detector progress

### DIFF
--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,6 +3,15 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
+Unreleased
+----------
+
+Changed:
+
+- Added frame counter progress for XspressDetector and acquire status for X3X2
+  list mode. Doesn't yet work for TTL/LVDS veto trigger mode (hardware-gated
+  triggers)
+
 
 0.5.0+qd0.7
 -----------

--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -6,7 +6,7 @@ Changes made by Quantum Detectors to this repository are recorded below.
 Unreleased
 ----------
 
-Changed:
+Added:
 
 - Added frame counter progress for XspressDetector and acquire status for X3X2
   list mode. Doesn't yet work for TTL/LVDS veto trigger mode (hardware-gated

--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -146,6 +146,7 @@ public:
                      int invert_veto) = 0;
   virtual int get_num_frames_read(int32_t *frames) = 0;
   virtual int get_current_tf(u_int32_t *current_tf) = 0;
+  virtual int is_itfg_running(bool *itfg_running) = 0;
   virtual int get_num_scalars(uint32_t *num_scalars) = 0;
   virtual int histogram_circ_ack(int channel,
                          uint32_t frame_number,

--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -145,6 +145,7 @@ public:
                      int invert_f0,
                      int invert_veto) = 0;
   virtual int get_num_frames_read(int32_t *frames) = 0;
+  virtual int get_current_tf(u_int32_t *current_tf) = 0;
   virtual int get_num_scalars(uint32_t *num_scalars) = 0;
   virtual int histogram_circ_ack(int channel,
                          uint32_t frame_number,

--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -147,6 +147,7 @@ public:
   virtual int get_num_frames_read(int32_t *frames) = 0;
   virtual int get_current_tf(u_int32_t *current_tf) = 0;
   virtual int is_itfg_running(bool *itfg_running) = 0;
+  virtual int is_itfg_waiting_for_trigger(bool *itfg_waiting) = 0;
   virtual int get_num_scalars(uint32_t *num_scalars) = 0;
   virtual int histogram_circ_ack(int channel,
                          uint32_t frame_number,

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -117,6 +117,7 @@ public:
                      int invert_veto);
   int get_num_frames_read(int32_t *frames);
   int get_current_tf(u_int32_t *current_tf);
+  int is_itfg_running(bool *itfg_running);
   int get_num_scalars(uint32_t *num_scalars);
   int histogram_circ_ack(int channel,
                          uint32_t frame_number,

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -118,6 +118,7 @@ public:
   int get_num_frames_read(int32_t *frames);
   int get_current_tf(u_int32_t *current_tf);
   int is_itfg_running(bool *itfg_running);
+  int is_itfg_waiting_for_trigger(bool *itfg_waiting);
   int get_num_scalars(uint32_t *num_scalars);
   int histogram_circ_ack(int channel,
                          uint32_t frame_number,

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -116,6 +116,7 @@ public:
                      int invert_f0,
                      int invert_veto);
   int get_num_frames_read(int32_t *frames);
+  int get_current_tf(u_int32_t *current_tf);
   int get_num_scalars(uint32_t *num_scalars);
   int histogram_circ_ack(int channel,
                          uint32_t frame_number,

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -152,6 +152,7 @@ public:
                      int invert_f0,
                      int invert_veto);
   int get_num_frames_read(int32_t *frames);
+  int get_current_tf(u_int32_t *current_tf);
   int get_num_scalars(uint32_t *num_scalars);
   int histogram_circ_ack(int channel,
                          uint32_t frame_number,

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -154,6 +154,7 @@ public:
   int get_num_frames_read(int32_t *frames);
   int get_current_tf(u_int32_t *current_tf);
   int is_itfg_running(bool *itfg_running);
+  int is_itfg_waiting_for_trigger(bool *itfg_waiting);
   int get_num_scalars(uint32_t *num_scalars);
   int histogram_circ_ack(int channel,
                          uint32_t frame_number,

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -153,6 +153,7 @@ public:
                      int invert_veto);
   int get_num_frames_read(int32_t *frames);
   int get_current_tf(u_int32_t *current_tf);
+  int is_itfg_running(bool *itfg_running);
   int get_num_scalars(uint32_t *num_scalars);
   int histogram_circ_ack(int channel,
                          uint32_t frame_number,

--- a/cpp/control/include/XspressDetector.h
+++ b/cpp/control/include/XspressDetector.h
@@ -157,6 +157,8 @@ public:
   std::vector<bool> getCardsConnected();
   
 private:
+  bool using_itfg();
+
   /** libxspress wrapper object */
   boost::shared_ptr<ILibXspress>  detector_;
   /** Pointer to DAQ object */

--- a/cpp/control/include/XspressDetector.h
+++ b/cpp/control/include/XspressDetector.h
@@ -265,6 +265,10 @@ private:
   /** StartAcquisition mutex for locking */
   boost::mutex                  start_acq_mutex_;
 
+  /** Used to track number of frames when using software triggers in list mode */
+  bool                          first_software_trigger_sent_;
+  bool                          manually_stopped_waiting_for_trigger_;
+
 };
 
 } /* namespace Xspress */

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -625,6 +625,20 @@ int LibXspressSimulator::get_current_tf(u_int32_t *current_tf)
   return status;
 }
 
+
+/**
+ * @brief Get whether the ITFG is running
+ * 
+ * @param[out] itfg_running Whether ITFG is running or not
+ * @return int Status code
+ */
+int LibXspressSimulator::is_itfg_running(bool *itfg_running)
+{
+  *itfg_running = acquisition_state_;
+  return XSP_STATUS_OK;
+}
+
+
 int LibXspressSimulator::get_num_scalars(uint32_t *num_scalars)
 {
   *num_scalars = XSP3_SW_NUM_SCALERS;

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -638,6 +638,21 @@ int LibXspressSimulator::is_itfg_running(bool *itfg_running)
   return XSP_STATUS_OK;
 }
 
+/**
+ * @brief Get whether the ITFG is waiting for trigger
+ * 
+ * Used when in software mode to correct the number of
+ * time frames completed
+ * 
+ * @param[out] itfg_waiting Whether ITFG is waiting for trigger
+ * @return int Status code
+ */
+int LibXspressSimulator::is_itfg_waiting_for_trigger(bool *itfg_waiting)
+{
+  // Shouldn't need to correct in simulation mode?
+  *itfg_waiting = false;
+  return XSP_STATUS_OK;
+}
 
 int LibXspressSimulator::get_num_scalars(uint32_t *num_scalars)
 {

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -604,6 +604,27 @@ int LibXspressSimulator::get_num_frames_read(int32_t *frames)
   return status;
 }
 
+/**
+ * @brief Get the current time frame of the Xspress system
+ * 
+ * Unlike get_num_frames_read this tracks the time frame of the Xspress system
+ * rather than how many frames have been read into shared memory.
+ * 
+ * This is used for list mode where the Xspress library doesn't receive the list
+ * mode data - instead the Odin frame receivers connect directly.
+ * 
+ * @param current_tf Current time frame
+ * @return int Status code
+ */
+int LibXspressSimulator::get_current_tf(u_int32_t *current_tf)
+{
+  // For the simulator just use get_num_frames_read
+  int32_t frames;
+  int status = get_num_frames_read(&frames);
+  *current_tf = frames;
+  return status;
+}
+
 int LibXspressSimulator::get_num_scalars(uint32_t *num_scalars)
 {
   *num_scalars = XSP3_SW_NUM_SCALERS;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include "dirent.h"
 #include <iostream>
+#include <limits>
 
 #include "LibXspressWrapper.h"
 #include "DebugLevelLogger.h"
@@ -905,7 +906,7 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
   }
 
   int xsp_status;
-  u_int32_t lowest_tf = 0;
+  u_int32_t lowest_tf = std::numeric_limits<u_int32_t>::max();
   u_int32_t time_reg = 0;
   u_int32_t tf = 0;
   for (int card = 0; card < num_cards; card++)
@@ -925,6 +926,8 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
 
   // Set the lowest value found
   *current_tf = lowest_tf;
+
+  LOG4CXX_INFO(logger_, "Current TF " << current_tf << " Lowest TF: " << lowest_tf);
 
   return XSP_STATUS_OK;
 }

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -911,6 +911,11 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
   u_int32_t tf = 0;
   bool finished = false;
 
+  // TODO: remove when done
+  bool itfg_counting = false;
+  bool itfg_running = false;
+  bool itfg_paused = false;
+
   for (int card = 0; card < num_cards; card++)
   {
     // Get the TF progress for the card
@@ -924,7 +929,17 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
     if (card == 0) finished = XSP3_GLOB_TSTAT_A_ITFG_FINISHED(time_reg);
 
     // TODO: remove when done
-    LOG4CXX_INFO(logger_, "Card " << card << " TF: " << tf);
+    itfg_counting = XSP3_GLOB_TSTAT_A_ITFG_COUNTING(time_reg);
+    itfg_running = XSP3_GLOB_TSTAT_A_ITFG_RUNNING(time_reg);
+    itfg_paused = XSP3_GLOB_TSTAT_A_ITFG_PAUSED(time_reg);
+    LOG4CXX_INFO(
+      logger_,
+      "Card " << card
+      << " TF: " << tf
+      << ", C: " << itfg_counting
+      << ", R: " << itfg_running
+      << ", P: " << itfg_paused
+    );
 
     // Track the card with the least progress
     if (tf < lowest_tf) lowest_tf = tf;
@@ -948,13 +963,13 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
  */
 int LibXspressWrapper::is_itfg_running(bool *itfg_running)
 {
-  LOG4CXX_DEBUG_LEVEL(1, logger_, "Getting current TF");
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Checking if ITFG is running");
 
   // Need to enable each channel individually to preserve the current control register value
   int num_cards = xsp3_get_num_cards(xsp_handle_);
   if (num_cards < 0)
   {
-    checkErrorCode("Error getting number of cards to get current TF", num_cards);
+    checkErrorCode("Error getting number of cards to check if ITFG running", num_cards);
     return XSP_STATUS_ERROR;
   }
 
@@ -968,7 +983,7 @@ int LibXspressWrapper::is_itfg_running(bool *itfg_running)
     // Get the TF progress for the card
     xsp_status = xsp3_get_glob_time_statA(xsp_handle_, card, &time_reg);
     if (xsp_status < 0) {
-      checkErrorCode("Error getting glob_time_statA for time frame progress", xsp_status);
+      checkErrorCode("Error getting glob_time_statA to check if running", xsp_status);
       return XSP_STATUS_ERROR;
     }
     card_running = XSP3_GLOB_TSTAT_A_ITFG_RUNNING(time_reg);
@@ -984,6 +999,37 @@ int LibXspressWrapper::is_itfg_running(bool *itfg_running)
   LOG4CXX_INFO(logger_, "Running: " << running);
   *itfg_running = running;
 
+  return XSP_STATUS_OK;
+}
+
+/**
+ * @brief Get whether the ITFG is waiting for trigger
+ * 
+ * Used when in software mode to correct the number of
+ * time frames completed
+ * 
+ * @param[out] itfg_waiting Whether ITFG is waiting for trigger
+ * @return int Status code
+ */
+int LibXspressWrapper::is_itfg_waiting_for_trigger(bool *itfg_waiting)
+{
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Checking if ITFG is waiting for trigger");
+
+  // Only need to check first card
+  u_int32_t time_reg = 0;
+  int xsp_status = xsp3_get_glob_time_statA(xsp_handle_, 0, &time_reg);
+  if (xsp_status < XSP3_OK) {
+    checkErrorCode("Checking ITFG is waiting", xsp_status);
+    return XSP_STATUS_ERROR;
+  }
+
+  bool paused = XSP3_GLOB_TSTAT_A_ITFG_PAUSED(time_reg);
+  bool running = XSP3_GLOB_TSTAT_A_ITFG_RUNNING(time_reg);
+
+  if (paused && running) *itfg_waiting = true;
+  else *itfg_waiting = false;
+
+  LOG4CXX_INFO(logger_, "Waiting: " << itfg_waiting);
   return XSP_STATUS_OK;
 }
 

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -895,7 +895,7 @@ int LibXspressWrapper::get_num_frames_read(int32_t *frames)
  */
 int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
 {
-  LOG4CXX_DEBUG_LEVEL(1, logger_, "Getting current TF");
+  // LOG4CXX_DEBUG_LEVEL(1, logger_, "Getting current TF");
 
   // Need to enable each channel individually to preserve the current control register value
   int num_cards = xsp3_get_num_cards(xsp_handle_);
@@ -911,11 +911,6 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
   u_int32_t tf = 0;
   bool finished = false;
 
-  // TODO: remove when done
-  bool itfg_counting = false;
-  bool itfg_running = false;
-  bool itfg_paused = false;
-
   for (int card = 0; card < num_cards; card++)
   {
     // Get the TF progress for the card
@@ -925,21 +920,8 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
       return XSP_STATUS_ERROR;
     }
     tf = XSP3_GLOB_TSTAT_A_FRAME(time_reg);
-    // Only seems to track on first card - presumably as master
+    // Check if the first card has completed
     if (card == 0) finished = XSP3_GLOB_TSTAT_A_ITFG_FINISHED(time_reg);
-
-    // TODO: remove when done
-    itfg_counting = XSP3_GLOB_TSTAT_A_ITFG_COUNTING(time_reg);
-    itfg_running = XSP3_GLOB_TSTAT_A_ITFG_RUNNING(time_reg);
-    itfg_paused = XSP3_GLOB_TSTAT_A_ITFG_PAUSED(time_reg);
-    LOG4CXX_INFO(
-      logger_,
-      "Card " << card
-      << " TF: " << tf
-      << ", C: " << itfg_counting
-      << ", R: " << itfg_running
-      << ", P: " << itfg_paused
-    );
 
     // Track the card with the least progress
     if (tf < lowest_tf) lowest_tf = tf;
@@ -948,9 +930,6 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
   // Set the lowest value found, and add one if first card complete
   if (finished) lowest_tf += 1;
   *current_tf = lowest_tf;
-
-  // TODO: remove when done
-  LOG4CXX_INFO(logger_, "Lowest TF: " << lowest_tf << "Finished: " << finished);
 
   return XSP_STATUS_OK;
 }
@@ -963,7 +942,7 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
  */
 int LibXspressWrapper::is_itfg_running(bool *itfg_running)
 {
-  LOG4CXX_DEBUG_LEVEL(1, logger_, "Checking if ITFG is running");
+  // LOG4CXX_DEBUG_LEVEL(1, logger_, "Checking if ITFG is running");
 
   // Need to enable each channel individually to preserve the current control register value
   int num_cards = xsp3_get_num_cards(xsp_handle_);
@@ -988,17 +967,11 @@ int LibXspressWrapper::is_itfg_running(bool *itfg_running)
     }
     card_running = XSP3_GLOB_TSTAT_A_ITFG_RUNNING(time_reg);
 
-    // TODO: remove when done
-    LOG4CXX_INFO(logger_, "Card " << card << " running: " << card_running);
-
     // If any are running, then we are running
     running |= card_running;
   }
 
-  // TODO: remove when done
-  LOG4CXX_INFO(logger_, "Running: " << running);
   *itfg_running = running;
-
   return XSP_STATUS_OK;
 }
 
@@ -1556,12 +1529,9 @@ int LibXspressWrapper::set_channel_sources(int run_flags)
 int LibXspressWrapper::setup_marker_channels()
 {
   LOG4CXX_INFO(logger_, "Configuring marker channels");
-  // TODO: ensure that changing the trigger mode does not override
-  // these settings - e.g. listening to rise and fall doesn't
-  // advance time frame twice
 
   // Apply for each channel
-  int num_marker_chans = 2; // TODO: find out if we can query this
+  int num_marker_chans = 2;
   int status = XSP_STATUS_OK;
   int xsp_status;
   u_int32_t chan_cont = 0;
@@ -1578,9 +1548,8 @@ int LibXspressWrapper::setup_marker_channels()
     chan_cont &= ~XSP3_CC_SEL_DATA(0xFF);
     if (chan % 2 == 0) chan_cont |= XSP3_CC_SEL_DATA(XSP3_CC_SEL_DATA_EXT0);
     else chan_cont |= XSP3_CC_SEL_DATA(XSP3_CC_SEL_DATA_EXT1);
-    chan_cont = 0; // TODO: find out correct value
+    chan_cont = 0;
 
-    // TODO: make sure we understand what chan_cont means for marker channels
     if (chan % 2 == 0) xsp_status = xsp3_setup_marker_chan(xsp_handle_, chan, chan_cont, 1, 1, 0);
     else xsp_status = xsp3_setup_marker_chan(xsp_handle_, chan, chan_cont, 1, 1, 1);
   }

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -890,7 +890,7 @@ int LibXspressWrapper::get_num_frames_read(int32_t *frames)
  * by xsp3_get_glob_time_statA. 24 bits are used by this value so we can report
  * up to 2**24 - 1 = 16,777,215 time frames.
  * 
- * @param current_tf Current time frame
+ * @param[out] current_tf Current time frame
  * @return int Status code
  */
 int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
@@ -936,6 +936,53 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
 
   // TODO: remove when done
   LOG4CXX_INFO(logger_, "Lowest TF: " << lowest_tf << "Finished: " << finished);
+
+  return XSP_STATUS_OK;
+}
+
+/**
+ * @brief Get whether the ITFG is running
+ * 
+ * @param[out] itfg_running Whether ITFG is running or not
+ * @return int Status code
+ */
+int LibXspressWrapper::is_itfg_running(bool *itfg_running)
+{
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Getting current TF");
+
+  // Need to enable each channel individually to preserve the current control register value
+  int num_cards = xsp3_get_num_cards(xsp_handle_);
+  if (num_cards < 0)
+  {
+    checkErrorCode("Error getting number of cards to get current TF", num_cards);
+    return XSP_STATUS_ERROR;
+  }
+
+  int xsp_status;
+  u_int32_t time_reg = 0;
+  bool running = false;
+  bool card_running = false;
+
+  for (int card = 0; card < num_cards; card++)
+  {
+    // Get the TF progress for the card
+    xsp_status = xsp3_get_glob_time_statA(xsp_handle_, card, &time_reg);
+    if (xsp_status < 0) {
+      checkErrorCode("Error getting glob_time_statA for time frame progress", xsp_status);
+      return XSP_STATUS_ERROR;
+    }
+    card_running = XSP3_GLOB_TSTAT_A_ITFG_RUNNING(time_reg);
+
+    // TODO: remove when done
+    LOG4CXX_INFO(logger_, "Card " << card << " running: " << card_running);
+
+    // If any are running, then we are running
+    running |= card_running;
+  }
+
+  // TODO: remove when done
+  LOG4CXX_INFO(logger_, "Running: " << running);
+  *itfg_running = running;
 
   return XSP_STATUS_OK;
 }

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -876,6 +876,59 @@ int LibXspressWrapper::get_num_frames_read(int32_t *frames)
   return status;
 }
 
+/**
+ * @brief Get the current time frame of the Xspress system
+ * 
+ * Unlike get_num_frames_read this tracks the time frame of the Xspress system
+ * rather than how many frames have been read into shared memory.
+ * 
+ * This is used for list mode where the Xspress library doesn't receive the list
+ * mode data - instead the Odin frame receivers connect directly.
+ * 
+ * This returns the lowest time frame returned by the Xspress cards as reported
+ * by xsp3_get_glob_time_statA. 24 bits are used by this value so we can report
+ * up to 2**24 - 1 = 16,777,215 time frames.
+ * 
+ * @param current_tf Current time frame
+ * @return int Status code
+ */
+int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
+{
+  LOG4CXX_DEBUG_LEVEL(1, logger_, "Getting current TF");
+
+  // Need to enable each channel individually to preserve the current control register value
+  int num_cards = xsp3_get_num_cards(xsp_handle_);
+  if (num_cards < 0)
+  {
+    checkErrorCode("Error getting number of cards to get current TF", num_cards);
+    return XSP_STATUS_ERROR;
+  }
+
+  int xsp_status;
+  u_int32_t lowest_tf = 0;
+  u_int32_t time_reg = 0;
+  u_int32_t tf = 0;
+  for (int card = 0; card < num_cards; card++)
+  {
+    // Get the TF progress for the card
+    xsp_status = xsp3_get_glob_time_statA(xsp_handle_, card, &time_reg);
+    if (xsp_status < 0) {
+      checkErrorCode("Error getting glob_time_statA for time frame progress", xsp_status);
+      return XSP_STATUS_ERROR;
+    }
+    tf = XSP3_GLOB_TSTAT_A_FRAME(time_reg);
+    LOG4CXX_INFO(logger_, "Card " << card << " TF: " << tf);
+
+    // Track the card with the least progress
+    if (tf < lowest_tf) lowest_tf = tf;
+  }
+
+  // Set the lowest value found
+  *current_tf = lowest_tf;
+
+  return XSP_STATUS_OK;
+}
+
 int LibXspressWrapper::get_num_scalars(uint32_t *num_scalars)
 {
   *num_scalars = XSP3_SW_NUM_SCALERS;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -909,6 +909,8 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
   u_int32_t lowest_tf = std::numeric_limits<u_int32_t>::max();
   u_int32_t time_reg = 0;
   u_int32_t tf = 0;
+  bool finished = false;
+
   for (int card = 0; card < num_cards; card++)
   {
     // Get the TF progress for the card
@@ -918,16 +920,22 @@ int LibXspressWrapper::get_current_tf(u_int32_t *current_tf)
       return XSP_STATUS_ERROR;
     }
     tf = XSP3_GLOB_TSTAT_A_FRAME(time_reg);
+    // Only seems to track on first card - presumably as master
+    if (card == 0) finished = XSP3_GLOB_TSTAT_A_ITFG_FINISHED(time_reg);
+
+    // TODO: remove when done
     LOG4CXX_INFO(logger_, "Card " << card << " TF: " << tf);
 
     // Track the card with the least progress
     if (tf < lowest_tf) lowest_tf = tf;
   }
 
-  // Set the lowest value found
+  // Set the lowest value found, and add one if first card complete
+  if (finished) lowest_tf += 1;
   *current_tf = lowest_tf;
 
-  LOG4CXX_INFO(logger_, "Current TF " << current_tf << " Lowest TF: " << lowest_tf);
+  // TODO: remove when done
+  LOG4CXX_INFO(logger_, "Lowest TF: " << lowest_tf << "Finished: " << finished);
 
   return XSP_STATUS_OK;
 }

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -1269,7 +1269,6 @@ bool XspressDetector::getXspAcquiring()
     }
     else if (xsp_mode_ == XSP_MODE_LIST && using_itfg())
     {
-      LOG4CXX_INFO(logger_, "Using ITFG status to check if running");
       // This only works if the ITFG is running - i.e. not using a gated
       // hardware trigger or software start/stop
       bool running;
@@ -1310,8 +1309,7 @@ uint32_t XspressDetector::getXspFramesRead()
       if (acquiring_)
       {
         // The reported TF is always 1 less when the system
-        // is waiting for a software trigger, except for the very
-        // first trigger
+        // is waiting for a software trigger (except for the first one)
         bool waiting;
         detector_->is_itfg_waiting_for_trigger(&waiting);
         if (waiting) frames++;
@@ -1322,7 +1320,6 @@ uint32_t XspressDetector::getXspFramesRead()
         if (manually_stopped_waiting_for_trigger_) frames++;
       }
     }
-    LOG4CXX_INFO(logger_, "Getting " << frames << " frames read for list mode");
   }
 
   return frames;

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -1267,9 +1267,11 @@ bool XspressDetector::getXspAcquiring()
         }
       }
     }
-    else if (xsp_mode_ == XSP_MODE_LIST)
+    else if (xsp_mode_ == XSP_MODE_LIST && using_itfg())
     {
-      // TODO: check if this works with external triggers
+      LOG4CXX_INFO(logger_, "Using ITFG status to check if running");
+      // This only works if the ITFG is running - i.e. not using a gated
+      // hardware trigger or software start/stop
       bool running;
       int status = detector_->is_itfg_running(&running);
       if (!running) acquiring_ = false;
@@ -1374,6 +1376,33 @@ std::vector<int32_t> XspressDetector::getChannelsConnected()
 std::vector<bool> XspressDetector::getCardsConnected()
 {
   return cards_connected_;
+}
+
+/**
+ * @brief Returns whether the acquisition will be using the ITFG
+ * 
+ * This is based on the trigger mode. The ITFG is used if the Xspress
+ * frames are internally-timed.
+ * 
+ * This will be false if we are using hardware-gated triggers or software
+ * start/stop.
+ * 
+ * @return true The ITFG will be used in an acquisition
+ * @return false The ITFG will not be used
+ */
+bool XspressDetector::using_itfg()
+{
+  switch(xsp_trigger_mode_)
+  {
+    case TM_TTL_VETO_ONLY:
+    case TM_TTL_BOTH:
+    case TM_LVDS_VETO_ONLY:
+    case TM_LVDS_BOTH:
+    case TM_SOFTWARE_START_STOP:
+      return false;
+    default:
+      return true;
+  }
 }
 
 } /* namespace Xspress */

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -1278,7 +1278,8 @@ uint32_t XspressDetector::getXspFramesRead()
   if (daq_){
     frames = daq_->getFramesRead();
   }
-  else
+  // Otherwise check if we are in list mode
+  else if (xsp_mode_ == XSP_MODE_LIST)
   {
     int status = detector_->get_current_tf(&frames);
     LOG4CXX_INFO(logger_, "Getting " << frames << " frames read for list mode");

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -1257,7 +1257,10 @@ bool XspressDetector::getXspAcquiring()
     }
     else if (xsp_mode_ == XSP_MODE_LIST)
     {
-      // TOOD: check if the Xspress system is acquiring
+      // TODO: check if this works with external triggers
+      bool running;
+      int status = detector_->is_itfg_running(&running);
+      if (!running) acquiring_ = false;
     }
   }
   // The second job is to return the acquiring state

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -1273,10 +1273,17 @@ void XspressDetector::resetXspAcqFailed()
 uint32_t XspressDetector::getXspFramesRead()
 {
   uint32_t frames = 0;
+
   // If DAQ exists return the counter from that object.
   if (daq_){
     frames = daq_->getFramesRead();
   }
+  else
+  {
+    int status = detector_->get_current_tf(&frames);
+    LOG4CXX_INFO(logger_, "Getting " << frames << " frames read for list mode");
+  }
+
   return frames;
 }
 

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -48,7 +48,9 @@ XspressDetector::XspressDetector(bool simulation) :
     xsp_debounce_(0),
     xsp_exposure_time_(1.0),
     xsp_frames_(1),
-    xsp_mode_(XSP_MODE_MCA)
+    xsp_mode_(XSP_MODE_MCA),
+    first_software_trigger_sent_(false),
+    manually_stopped_waiting_for_trigger_(false)
 {
   OdinData::configure_logging_mdc(OdinData::app_path.c_str());
   LOG4CXX_INFO(logger_, "Constructing XspressDetector");
@@ -559,6 +561,10 @@ int XspressDetector::startAcquisition()
 
   if (status == XSP_STATUS_OK){
     if (xsp_trigger_mode_ == TM_SOFTWARE){
+      // Reset first software trigger state
+      first_software_trigger_sent_ = false;
+      manually_stopped_waiting_for_trigger_ = false;
+
       // Arm for soft trigger
       status = detector_->histogram_arm(0);
     } else {
@@ -589,6 +595,11 @@ int XspressDetector::stopAcquisition()
 {
   int status = XSP_STATUS_OK;
   if (acquiring_){
+    // Check if the system was waiting for a trigger at the time
+    bool waiting;
+    detector_->is_itfg_waiting_for_trigger(&waiting);
+    if (waiting) manually_stopped_waiting_for_trigger_ = true;
+
     if (xsp_mode_ == XSP_MODE_MCA){
       // If the DAQ object exists then stop any acquisition loop
       if (daq_){
@@ -607,10 +618,10 @@ int XspressDetector::sendSoftwareTrigger()
 {
   int status = XSP_STATUS_OK;
   if (acquiring_){
-    // TODO: BEN: handle what happens in list mode if required
     if (xsp_trigger_mode_ == TM_SOFTWARE){
       status = detector_->histogram_continue(0);
       status |= detector_->histogram_pause(0);
+      first_software_trigger_sent_ = true;
     } else {
       setErrorString("Cannot send software trigger, trigger_mode is not [software]");
       status = XSP_STATUS_ERROR;
@@ -1247,6 +1258,7 @@ bool XspressDetector::getXspAcquiring()
       // Check the DAQ flag.  If it is false then reset our flag
       if (!daq_->getAcqRunning()){
         acquiring_ = false;
+
         // Check to see if the acquisition failed
         if (daq_->getAcqFailed()){
           // If the acquisition failed propagate the error
@@ -1289,6 +1301,25 @@ uint32_t XspressDetector::getXspFramesRead()
   else if (xsp_mode_ == XSP_MODE_LIST)
   {
     int status = detector_->get_current_tf(&frames);
+
+    // Correct for software trigger mode
+    if (xsp_trigger_mode_ == TM_SOFTWARE && first_software_trigger_sent_)
+    {
+      if (acquiring_)
+      {
+        // The reported TF is always 1 less when the system
+        // is waiting for a software trigger, except for the very
+        // first trigger
+        bool waiting;
+        detector_->is_itfg_waiting_for_trigger(&waiting);
+        if (waiting) frames++;
+      }
+      else
+      {
+        // If we are idle we may need to add one if we were manually stopped
+        if (manually_stopped_waiting_for_trigger_) frames++;
+      }
+    }
     LOG4CXX_INFO(logger_, "Getting " << frames << " frames read for list mode");
   }
 

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -1255,6 +1255,10 @@ bool XspressDetector::getXspAcquiring()
         }
       }
     }
+    else if (xsp_mode_ == XSP_MODE_LIST)
+    {
+      // TOOD: check if the Xspress system is acquiring
+    }
   }
   // The second job is to return the acquiring state
   return acquiring_;


### PR DESCRIPTION
This adds a working frame counter when the Xspress system is in list mode. It has been tested with the following trigger modes:

- Software
- Hardware (external start + internal timing)
- Burst

It required some janky workaround for software trigger mode to correct the frame counter behaviour, but works currently.

TODO:

- TTL Veto only (ITFG isn't running here so cannot be used directly - assume manual stop?)