### PR TITLE
Feature/reset ts on run

### DIFF
--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,6 +3,16 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
+0.5.0+qd0.9
+-----------
+
+Added:
+
+- Added XSP3_CLK_FLAGS_TS_SYNC when configuring clocks for X3X2 so that the
+  timestamps reset. This avoids the timestamps for markers and event channels
+  drifting apart when the system is not running
+
+
 0.5.0+qd0.8
 -----------
 

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1364,11 +1364,14 @@ int LibXspressWrapper::setup_clocks(int num_cards)
   if (xsp3_is_xsp3m_plus(0) == 1)
   {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 midplane clock");
+    // Also configure XSP3_CLK_FLAGS_TS_SYNC to reset timestamps to 0 on card 0 run,
+    // otherwise the timestamp for the marker channels and event channels drift
+    // apart.
     xsp_status = xsp3_clocks_setup(
       xsp_handle_,
       -1,
       XSP4_CLK_SRC_MIDPLN_LMK61E2,
-      XSP3_CLK_FLAGS_NO_DITHER,
+      XSP3_CLK_FLAGS_NO_DITHER | XSP3_CLK_FLAGS_TS_SYNC,
       0
     );
     // < 0 for error, 0 for Xspress 3 success and clock frequency for other models


### PR DESCRIPTION
This adds the XSP3_CLK_FLAGS_TS_SYNC flag during clocks setup for X3X2. This resets the timestamps to zero when starting a new acquisition (i.e. running the system).

This is to prevent the mismatch in timestamps between event and marker channels, as they drift apart when the system is idle - due to the real channels continuing to count up.