### PR TITLE
Fix overallocation of memory for channels and also set default batch …

### DIFF
--- a/QD-CHANGELOG.rst
+++ b/QD-CHANGELOG.rst
@@ -3,6 +3,19 @@ Change log
 
 Changes made by Quantum Detectors to this repository are recorded below.
 
+0.5.0+qd0.10
+------------
+
+Fixed:
+
+- Fixed memory allocation for number of channels in XspressProcessPlugin. Would
+  previously allocate one additional block than necessary in the loop.
+- Set batch size in FPXspressAdapter to 1 (instead of 0). This fixes an issue
+  where the XspressProcessPlugin would allocate no memory for the MCA data and
+  cause it to crash if the data saving was not enabled first to set it to a
+  non-zero value.
+
+
 0.5.0+qd0.9
 -----------
 

--- a/cpp/data/frameProcessor/src/XspressProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/XspressProcessPlugin.cpp
@@ -178,7 +178,7 @@ void XspressProcessPlugin::configure(OdinData::IpcMessage& config, OdinData::Ipc
       if (config.get_param<uint32_t>(XspressProcessPlugin::CONFIG_CHUNK) > MAX_SCALAR_MEM_BLOCK_SIZE)
       {
         this->frames_per_block_ = 4096;
-        LOG4CXX_WARN(logger_, "Batch size configured to a value grater than the maximum allowed. Forcing it to " << MAX_SCALAR_MEM_BLOCK_SIZE);
+        LOG4CXX_WARN(logger_, "Batch size configured to a value greater than the maximum allowed. Forcing it to " << MAX_SCALAR_MEM_BLOCK_SIZE);
       }
       else
       {
@@ -316,7 +316,7 @@ void XspressProcessPlugin::setup_memory_allocation()
   // Allocate one block of memory for each channel
   uint32_t frame_size = num_energy_bins_ * num_aux_ * sizeof(uint32_t);
   LOG4CXX_DEBUG_LEVEL(3, logger_, "frames_per_block_ inside the setup_memory_allocation method: " << frames_per_block_);
-  for (int index = 0; index <= num_channels_; index++){
+  for (int index = 0; index < num_channels_; index++){
     boost::shared_ptr<XspressMemoryBlock> ptr = boost::shared_ptr<XspressMemoryBlock>(new XspressMemoryBlock());
     ptr->set_size(frame_size, frames_per_block_);
     memory_ptrs_.push_back(ptr);

--- a/python/src/xspress_detector/control/fp_xspress_adapter.py
+++ b/python/src/xspress_detector/control/fp_xspress_adapter.py
@@ -50,7 +50,7 @@ class FPXspressAdapter(FrameProcessorAdapter):
         self._num_channels = 0
         self._num_process = 1
         self._mca_per_client = 0
-        self._batch_size = 0
+        self._batch_size = 1
         super(FPXspressAdapter, self).__init__(**kwargs)
 
     def initialize(self, adapters):


### PR DESCRIPTION
…size to 1 to fix allocating zero memory when the process plugin is initially configured by the Odin FP Xspress adapter

- This sets the initial batch size when in MCA mode to 1 (for the XspressProcessPlugin). This prevents the frame processors from crashing when acquiring MCA data before enabling file saving, as memory is now allocated by default for a single MCA frame per channel
- Remove overallocation of memory in MCA mode by the XspressProcessPlugin. The loop to allocate memory for each channel would run one more iteration than needed based on the number of configured channels