### PR TITLE
Feature/reset ts option

### DIFF
--- a/cpp/control/include/ILibXspress.h
+++ b/cpp/control/include/ILibXspress.h
@@ -187,7 +187,7 @@ public:
   virtual int set_window(int chan, int sca, int llm, int hlm) = 0;
   virtual int set_sca_thresh(int chan, int value) = 0;
   virtual int set_trigger_input(bool list_mode) = 0;
-  virtual int setup_clocks(int num_cards) = 0;
+  virtual int setup_clocks(int num_cards, int reset_ts) = 0;
   virtual int enable_list_mode_resets() = 0;
   virtual int set_channel_sources(int run_flags) = 0;
   virtual int setup_marker_channels() = 0;

--- a/cpp/control/include/LibXspressSimulator.h
+++ b/cpp/control/include/LibXspressSimulator.h
@@ -158,7 +158,7 @@ public:
   int set_window(int chan, int sca, int llm, int hlm);
   int set_sca_thresh(int chan, int value);
   int set_trigger_input(bool list_mode);
-  int setup_clocks(int num_cards);
+  int setup_clocks(int num_cards, int reset_ts);
   int enable_list_mode_resets();
   int set_channel_sources(int run_flags);
   int setup_marker_channels();

--- a/cpp/control/include/LibXspressWrapper.h
+++ b/cpp/control/include/LibXspressWrapper.h
@@ -194,7 +194,7 @@ public:
   int set_window(int chan, int sca, int llm, int hlm);
   int set_sca_thresh(int chan, int value);
   int set_trigger_input(bool list_mode);
-  int setup_clocks(int num_cards);
+  int setup_clocks(int num_cards, int reset_ts);
   int enable_list_mode_resets();
   int set_channel_sources(int run_flags);
   int setup_marker_channels();

--- a/cpp/control/include/XspressController.h
+++ b/cpp/control/include/XspressController.h
@@ -88,6 +88,7 @@ private:
   static const std::string CONFIG_XSP_RUN_FLAGS;
   static const std::string CONFIG_XSP_DTC_ENERGY;
   static const std::string CONFIG_XSP_TRIGGER_MODE;
+  static const std::string CONFIG_XSP_RESET_TS;
   static const std::string CONFIG_XSP_INVERT_F0;
   static const std::string CONFIG_XSP_INVERT_VETO;
   static const std::string CONFIG_XSP_DEBOUNCE;

--- a/cpp/control/include/XspressDetector.h
+++ b/cpp/control/include/XspressDetector.h
@@ -105,6 +105,7 @@ public:
   double getXspDTCEnergy();
   void setXspTriggerMode(int mode);
   int getXspTriggerMode();
+  void setXspResetTs(int mode);
   void setXspInvertF0(int invert_f0);
   int getXspInvertF0();
   void setXspInvertVeto(int invert_veto);

--- a/cpp/control/include/XspressDetector.h
+++ b/cpp/control/include/XspressDetector.h
@@ -209,6 +209,8 @@ private:
   double                        xsp_clock_period_;
   /** Trigger mode */
   int                           xsp_trigger_mode_;
+  /** Reset Time Stamp */
+  int                           xsp_reset_timestamp_;
   /** Invert f0 */
   int                           xsp_invert_f0_;
   /** Invert veto */

--- a/cpp/control/src/LibXspressSimulator.cpp
+++ b/cpp/control/src/LibXspressSimulator.cpp
@@ -1007,7 +1007,7 @@ int LibXspressSimulator::set_trigger_input(bool list_mode)
   return XSP_STATUS_OK;
 }
 
-int LibXspressSimulator::setup_clocks(int num_cards)
+int LibXspressSimulator::setup_clocks(int num_cards, int reset_ts)
 {
   // This is a no op for the simulator
   return XSP_STATUS_OK;

--- a/cpp/control/src/LibXspressWrapper.cpp
+++ b/cpp/control/src/LibXspressWrapper.cpp
@@ -1372,25 +1372,28 @@ int LibXspressWrapper::set_trigger_input(bool list_mode)
  * is used as the clock source.
  * 
  * @param[in] num_cards Number of cards
+ * @param[in] reset_ts reset TS on or off
  * @return int Status whether we configured successfully or not
  */
-int LibXspressWrapper::setup_clocks(int num_cards)
+int LibXspressWrapper::setup_clocks(int num_cards, int reset_ts)
 {
   int status = XSP_STATUS_OK;
   int xsp_status;
+  int RESET_TS = 0;
+  // reset the TS if the reset_ts is 1
+  if (reset_ts) {
+    RESET_TS = XSP3_CLK_FLAGS_TS_SYNC;
+  }
 
   // Need to set up clocks specifically for X3X2 models for triggering to work
   if (xsp3_is_xsp3m_plus(0) == 1)
   {
     LOG4CXX_DEBUG_LEVEL(1, logger_, "Xspress wrapper configuring X3X2 midplane clock");
-    // Also configure XSP3_CLK_FLAGS_TS_SYNC to reset timestamps to 0 on card 0 run,
-    // otherwise the timestamp for the marker channels and event channels drift
-    // apart.
     xsp_status = xsp3_clocks_setup(
       xsp_handle_,
       -1,
-      XSP4_CLK_SRC_MIDPLN_LMK61E2,
-      XSP3_CLK_FLAGS_NO_DITHER | XSP3_CLK_FLAGS_TS_SYNC,
+      XSP4_CLK_SRC_MIDPLN_LMK61E2, 
+      XSP3_CLK_FLAGS_NO_DITHER | RESET_TS,
       0
     );
     // < 0 for error, 0 for Xspress 3 success and clock frequency for other models
@@ -1408,6 +1411,7 @@ int LibXspressWrapper::setup_clocks(int num_cards)
       status = XSP_STATUS_ERROR;
     }
   }
+  // We don't setup clocks if it is not X3X2
   return status;
 }
 

--- a/cpp/control/src/XspressController.cpp
+++ b/cpp/control/src/XspressController.cpp
@@ -565,7 +565,9 @@ void XspressController::configureXsp(OdinData::IpcMessage& config, OdinData::Ipc
   if (config.has_param(XspressController::CONFIG_XSP_RESET_TS)) {
     int reset_ts = config.get_param<int>(XspressController::CONFIG_XSP_RESET_TS);
     LOG4CXX_DEBUG_LEVEL(1, logger_, "reset_ts set to  " << reset_ts);
+    printf("Setting reset_ts to %d\n", reset_ts);
     xsp_->setXspResetTs(reset_ts);
+    xsp_->setupClocks();
   }
 
   // Check for invert_f0 parameter

--- a/cpp/control/src/XspressController.cpp
+++ b/cpp/control/src/XspressController.cpp
@@ -567,7 +567,6 @@ void XspressController::configureXsp(OdinData::IpcMessage& config, OdinData::Ipc
     LOG4CXX_DEBUG_LEVEL(1, logger_, "reset_ts set to  " << reset_ts);
     printf("Setting reset_ts to %d\n", reset_ts);
     xsp_->setXspResetTs(reset_ts);
-    xsp_->setupClocks();
   }
 
   // Check for invert_f0 parameter

--- a/cpp/control/src/XspressController.cpp
+++ b/cpp/control/src/XspressController.cpp
@@ -41,6 +41,7 @@ const std::string XspressController::CONFIG_XSP_USE_RESGRADES         = "use_res
 const std::string XspressController::CONFIG_XSP_RUN_FLAGS             = "run_flags";
 const std::string XspressController::CONFIG_XSP_DTC_ENERGY            = "dtc_energy";
 const std::string XspressController::CONFIG_XSP_TRIGGER_MODE          = "trigger_mode";
+const std::string XspressController::CONFIG_XSP_RESET_TS              = "reset_ts";
 const std::string XspressController::CONFIG_XSP_INVERT_F0             = "invert_f0";
 const std::string XspressController::CONFIG_XSP_INVERT_VETO           = "invert_veto";
 const std::string XspressController::CONFIG_XSP_DEBOUNCE              = "debounce";
@@ -558,6 +559,13 @@ void XspressController::configureXsp(OdinData::IpcMessage& config, OdinData::Ipc
     int trigger_mode = config.get_param<int>(XspressController::CONFIG_XSP_TRIGGER_MODE);
     LOG4CXX_DEBUG_LEVEL(1, logger_, "trigger_mode set to  " << trigger_mode);
     xsp_->setXspTriggerMode(trigger_mode);
+  }
+
+  // Check for reset time stamp parameter
+  if (config.has_param(XspressController::CONFIG_XSP_RESET_TS)) {
+    int reset_ts = config.get_param<int>(XspressController::CONFIG_XSP_RESET_TS);
+    LOG4CXX_DEBUG_LEVEL(1, logger_, "reset_ts set to  " << reset_ts);
+    xsp_->setXspResetTs(reset_ts);
   }
 
   // Check for invert_f0 parameter

--- a/cpp/control/src/XspressController.cpp
+++ b/cpp/control/src/XspressController.cpp
@@ -565,7 +565,6 @@ void XspressController::configureXsp(OdinData::IpcMessage& config, OdinData::Ipc
   if (config.has_param(XspressController::CONFIG_XSP_RESET_TS)) {
     int reset_ts = config.get_param<int>(XspressController::CONFIG_XSP_RESET_TS);
     LOG4CXX_DEBUG_LEVEL(1, logger_, "reset_ts set to  " << reset_ts);
-    printf("Setting reset_ts to %d\n", reset_ts);
     xsp_->setXspResetTs(reset_ts);
   }
 

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -528,6 +528,7 @@ int XspressDetector::writeDTCParams()
 
 int XspressDetector::setTriggerMode()
 {
+  printf("Setting trigger mode %d\n", xsp_trigger_mode_);
   return detector_->setTriggerMode(xsp_frames_,
                                   xsp_exposure_time_,
                                   xsp_clock_period_,
@@ -915,6 +916,7 @@ int XspressDetector::getXspTriggerMode()
 void XspressDetector::setXspResetTs(int mode)
 {
   xsp_reset_timestamp_ = mode;
+  reconnectRequired();
 }
 
 void XspressDetector::setXspInvertF0(int invert_f0)

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -911,6 +911,11 @@ int XspressDetector::getXspTriggerMode()
   return xsp_trigger_mode_;
 }
 
+void XspressDetector::setXspResetTs(int mode)
+{
+  xsp_reset_timestamp_ = mode;
+}
+
 void XspressDetector::setXspInvertF0(int invert_f0)
 {
   xsp_invert_f0_ = invert_f0;

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -219,6 +219,7 @@ int XspressDetector::setupClocks()
 {
   int status = XSP_STATUS_OK;
   if (checkConnected()){
+    printf("Setting up clocks with reset_ts = %d\n", xsp_reset_timestamp_);
     status = detector_->setup_clocks(xsp_num_cards_, xsp_reset_timestamp_);
     if (status != XSP_STATUS_OK)
     {

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -219,7 +219,7 @@ int XspressDetector::setupClocks()
 {
   int status = XSP_STATUS_OK;
   if (checkConnected()){
-    printf("Setting up clocks with reset_ts = %d\n", xsp_reset_timestamp_);
+    LOG4CXX_INFO(logger_, "Setting up clocks with reset_ts = " << xsp_reset_timestamp_);
     status = detector_->setup_clocks(xsp_num_cards_, xsp_reset_timestamp_);
     if (status != XSP_STATUS_OK)
     {
@@ -528,7 +528,6 @@ int XspressDetector::writeDTCParams()
 
 int XspressDetector::setTriggerMode()
 {
-  printf("Setting trigger mode %d\n", xsp_trigger_mode_);
   return detector_->setTriggerMode(xsp_frames_,
                                   xsp_exposure_time_,
                                   xsp_clock_period_,
@@ -913,10 +912,12 @@ int XspressDetector::getXspTriggerMode()
   return xsp_trigger_mode_;
 }
 
-void XspressDetector::setXspResetTs(int mode)
+void XspressDetector::setXspResetTs(int reset_timestamp_)
 {
-  xsp_reset_timestamp_ = mode;
-  reconnectRequired();
+  if (reset_timestamp_ != xsp_reset_timestamp_){
+    xsp_reset_timestamp_ = reset_timestamp_;
+    reconnectRequired();
+  }
 }
 
 void XspressDetector::setXspInvertF0(int invert_f0)

--- a/cpp/control/src/XspressDetector.cpp
+++ b/cpp/control/src/XspressDetector.cpp
@@ -43,6 +43,7 @@ XspressDetector::XspressDetector(bool simulation) :
     xsp_dtc_energy_(0.0),
     xsp_clock_period_(0),
     xsp_trigger_mode_(TM_SOFTWARE),
+    xsp_reset_timestamp_(0),
     xsp_invert_f0_(0),
     xsp_invert_veto_(0),
     xsp_debounce_(0),
@@ -218,7 +219,7 @@ int XspressDetector::setupClocks()
 {
   int status = XSP_STATUS_OK;
   if (checkConnected()){
-    status = detector_->setup_clocks(xsp_num_cards_);
+    status = detector_->setup_clocks(xsp_num_cards_, xsp_reset_timestamp_);
     if (status != XSP_STATUS_OK)
     {
       setErrorString("Failed to configure card clocks");

--- a/python/src/xspress_detector/control/detector.py
+++ b/python/src/xspress_detector/control/detector.py
@@ -256,6 +256,8 @@ class XspressDetectorStr:
     CONFIG_DEBOUNCE = "debounce"
     CONFIG_EXPOSURE_TIME = "exposure_time"
     CONFIG_NUM_IMAGES = "num_images"  # so only "num_images" is used
+    CONFIG_RESET_TS = "reset_ts"
+
 
     CONFIG_MODE = "mode"
     CONFIG_MODE_CONTROL = "mode_control"
@@ -645,6 +647,15 @@ class XspressDetector(object):
                         self._put,
                         MessageType.CONFIG,
                         XspressDetectorStr.CONFIG_NUM_IMAGES,
+                    ),
+                ),
+                XspressDetectorStr.CONFIG_RESET_TS: ValueParameter(
+                    int,
+                    0,
+                    partial(
+                        self._put,
+                        MessageType.CONFIG,
+                        XspressDetectorStr.CONFIG_RESET_TS,
                     ),
                 ),
                 XspressDetectorStr.CONFIG_SCA5_LOW: ListParameter(


### PR DESCRIPTION
Changes to the xspress-detector side to inpliment the new PV which changes the setup clocks call to either use the reset_TS flag or not depending on user request.

Workings shown on confluence page https://quantumdetectors.atlassian.net/wiki/x/BgD8MgE (Marker Channel syncronisation with Event channels)